### PR TITLE
build: Don't hardcode native llvm paths.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             ./toolchains
       - name: Build
         run: |
-          meson setup --cross-file build-win64.txt --native-file build-osx.txt -Dlocal_native_llvm=true -Dbuild_airconv_for_windows=true build --buildtype debugoptimized
+          meson setup --cross-file build-win64.txt --native-file build-osx.txt -Dnative_llvm_path=toolchains/llvm-darwin -Dbuild_airconv_for_windows=true build --buildtype debugoptimized
           meson compile -C build
       - name: Tar
         run: tar -zcf artifacts.tar.gz build/src
@@ -48,7 +48,7 @@ jobs:
           path: artifacts.tar.gz
       - name: Build (release)
         run: |
-          meson setup --cross-file build-win64.txt --native-file build-osx.txt -Dlocal_native_llvm=true build-release --buildtype release
+          meson setup --cross-file build-win64.txt --native-file build-osx.txt -Dnative_llvm_path=toolchains/llvm-darwin build-release --buildtype release
           meson compile -C build-release
       - name: Tar (release)
         run: tar -zcf artifacts-release.tar.gz build-release/src

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following environment variables can be used for **debugging** purposes.
 After cloning this repository, inside the DXMT directory, run
 ```sh
 ./configure.sh
-meson setup --cross-file build-win64.txt --native-file build-osx.txt -Dlocal_native_llvm=true build
+meson setup --cross-file build-win64.txt --native-file build-osx.txt -Dnative_llvm_path=toolchains/llvm-darwin build
 ```
 `./configure.sh` will take some time (~1 hour) to configure the development environment, you only run it once.
 

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,4 @@
-option('local_native_llvm', type : 'boolean', value : false)
+option('native_llvm_path', type : 'string', value: '/usr/local/opt/llvm@15')
 option('build_airconv_for_windows', type : 'boolean', value : false)
 option('dxmt_debug', type : 'boolean', value : false)
 option('wine_build_path', type : 'string')

--- a/src/airconv/darwin/meson.build
+++ b/src/airconv/darwin/meson.build
@@ -1,35 +1,24 @@
+native_llvm_path = get_option('native_llvm_path')
 
-use_local_native_llvm = get_option('local_native_llvm')
-
-if use_local_native_llvm
-# At project root:
-# 
-# mkdir -p ./toolchains/llvm-darwin-build
-# cmake -B ./toolchains/llvm-darwin-build -S ./toolchains/llvm-project/llvm-darwin \
-#   -DCMAKE_INSTALL_PREFIX="$(pwd)/toolchains/llvm-darwin" \
-#   -DLLVM_ENABLE_ASSERTIONS=On \
-#   -DCMAKE_BUILD_TYPE=Release \
-#   -DBUG_REPORT_URL="https://github.com/3Shain/dxmt" \
-#   -DPACKAGE_VENDOR="DXMT" \
-#   -DLLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO=Off \
-#   -G Ninja
-# pushd ./toolchains/llvm-darwin-build
-# ninja
-# ninja install
-# popd
-
-llvm_include_path_darwin = include_directories('../../../toolchains/llvm-darwin/include') # FIXME: in favor of path relative to project
-llvm_ld_flags_darwin = [
- '-L'+join_paths(meson.source_root(), 'toolchains/llvm-darwin/lib'),
- '-lm', '-lz', '-lcurses', '-lxml2'
-]
+if not native_llvm_path.startswith('/')
+  # Meson only allows relative include paths in case the toolchains are located inside
+  # of the project source root, so handle that here.
+  llvm_include_path_darwin = include_directories(join_paths('../../..', native_llvm_path, 'include'))
+  native_llvm_path = join_paths(meson.project_source_root(), native_llvm_path)
 else
-# `brew install llvm@15`
-llvm_include_path_darwin = include_directories('/usr/local/opt/llvm@15/include') # FIXME: in favor of path relative to project
+  llvm_include_path_darwin = include_directories(join_paths(native_llvm_path, 'include'))
+endif
+
 llvm_ld_flags_darwin = [
- '-L'+join_paths('/usr/local/opt/llvm@15/lib'),
- '-lm', '-lz', '-lcurses', '-lxml2', '/usr/local/opt/zstd/lib/libzstd.a', '/usr/local/opt/llvm@15/lib/libunwind.a'
+  '-L'+join_paths(native_llvm_path, 'lib'),
+  '-lm', '-lz', '-lcurses', '-lxml2'
 ]
+
+if native_llvm_path.startswith('/usr/local/opt')
+  llvm_ld_flags_darwin = [
+    llvm_ld_flags_darwin,
+    '/usr/local/opt/zstd/lib/libzstd.a', '/usr/local/opt/llvm@15/lib/libunwind.a'
+  ]
 endif
 
 airconv_lib_darwin = static_library('airconv', airconv_src,


### PR DESCRIPTION
Meson doesn't allow absolute paths within the source tree, so this would be much cleaner if we put the toolchains outside of the source tree. But that requires the other toolchain dependencies to be updated in a similar way first.