### PR TITLE
Fix `D3D10_SB_OPERAND_INDEX_REPRESENTATION`

### DIFF
--- a/libs/DXBCParser/d3d12tokenizedprogramformat.hpp
+++ b/libs/DXBCParser/d3d12tokenizedprogramformat.hpp
@@ -995,8 +995,8 @@ typedef enum D3D10_SB_OPERAND_INDEX_REPRESENTATION
                                                      //   (HI32:LO32) followed
                                                      //   by extra operand
 } D3D10_SB_OPERAND_INDEX_REPRESENTATION;
-#define D3D10_SB_OPERAND_INDEX_REPRESENTATION_SHIFT(Dim) (22+3*((Dim)&3))
-#define D3D10_SB_OPERAND_INDEX_REPRESENTATION_MASK(Dim) (0x3<<D3D10_SB_OPERAND_INDEX_REPRESENTATION_SHIFT(Dim))
+#define D3D10_SB_OPERAND_INDEX_REPRESENTATION_SHIFT(Dim) (22+3*((Dim)&7))
+#define D3D10_SB_OPERAND_INDEX_REPRESENTATION_MASK(Dim) (0x7<<D3D10_SB_OPERAND_INDEX_REPRESENTATION_SHIFT(Dim))
 
 // DECODER MACRO: Determine from OperandToken0 what representation
 // an operand index is provided as (D3D10_SB_OPERAND_INDEX_REPRESENTATION enum),


### PR DESCRIPTION
The index representation in the operand token is a 3 bit value (`[30:28]`, `[27:25]`, `[24:22]`).

For now, `D3D10_SB_OPERAND_INDEX_REPRESENTATION_MASK` is `0x3`, so `D3D10_SB_OPERAND_INDEX_IMMEDIATE64_PLUS_RELATIVE` value is always mapped as `D3D10_SB_OPERAND_INDEX_IMMEDIATE32`