### PR TITLE
Fix a typo in a string + fix some wrong assignments when initializing the air types

### DIFF
--- a/src/airconv/air_type.cpp
+++ b/src/airconv/air_type.cpp
@@ -104,13 +104,13 @@ AirType::AirType(LLVMContext &context) : context(context) {
   _texture_buffer =
     get_or_create_struct(context, "struct._texture_buffer_1d_t");
 
-  _texture2d = get_or_create_struct(context, "struct._depth_2d_t");
-  _texture2d_array = get_or_create_struct(context, "struct._depth_2d_array_t");
-  _texture2d_ms = get_or_create_struct(context, "struct._depth_2d_ms_t");
-  _texture2d_ms_array =
+  _depth2d = get_or_create_struct(context, "struct._depth_2d_t");
+  _depth2d_array = get_or_create_struct(context, "struct._depth_2d_array_t");
+  _depth2d_ms = get_or_create_struct(context, "struct._depth_2d_ms_t");
+  _depth2d_ms_array =
     get_or_create_struct(context, "struct._depth_2d_ms_array_t");
-  _texture_cube = get_or_create_struct(context, "struct._depth_cube_t");
-  _texture_cube_array =
+  _depth_cube = get_or_create_struct(context, "struct._depth_cube_t");
+  _depth_cube_array =
     get_or_create_struct(context, "struct._depth_cube_array_t");
 
   _sampler = get_or_create_struct(context, "struct._sampler_t");

--- a/src/airconv/dxbc_converter_gs.cpp
+++ b/src/airconv/dxbc_converter_gs.cpp
@@ -176,7 +176,7 @@ convert_dxbc_geometry_shader(
   auto const zero_const = builder.getInt32(0);
   auto const one_const = builder.getInt32(1);
   auto const two_const = builder.getInt32(2);
-  auto next_write_vertex = builder.CreateAlloca(types._int, nullptr, "next_write_veretx");
+  auto next_write_vertex = builder.CreateAlloca(types._int, nullptr, "next_write_vertex");
   builder.CreateStore(zero_const, next_write_vertex);
   auto vertex_offset = builder.CreateAlloca(types._int, nullptr, "vertex_offset");
   builder.CreateStore(zero_const, vertex_offset);


### PR DESCRIPTION
This PR fixes some minor typos I noticed. They all seem to be harmless.