### PR TITLE
Update UInt32ToPtr to be a static inline

### DIFF
--- a/src/winemetal/unix/winemetal_unix.c
+++ b/src/winemetal/unix/winemetal_unix.c
@@ -1656,7 +1656,7 @@ thunk_SM50GetArgumentsInfo(void *args) {
   return STATUS_SUCCESS;
 }
 
-inline void *
+static inline void *
 UInt32ToPtr(uint32_t v) {
   return (void *)(uint64_t)v;
 }


### PR DESCRIPTION
This fixes the issue that I got on my macos (Apple M1 Pro):

```
Undefined symbols for architecture x86_64:
    "_UInt32ToPtr", referenced from:
        _sm50_compilation_argument32_convert in winemetal_unix.c.o
        _sm50_compilation_argument32_convert in winemetal_unix.c.o
        _sm50_compilation_argument32_convert in winemetal_unix.c.o
        _thunk32_SM50Initialize in winemetal_unix.c.o
        _thunk32_SM50Initialize in winemetal_unix.c.o
        _thunk32_SM50Initialize in winemetal_unix.c.o
        _thunk32_SM50Initialize in winemetal_unix.c.o
        ...
  ld: symbol(s) not found for architecture x86_64
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```