### PR TITLE
Fix malloc/free undeclared identifier errors with recent Xcode 26 betas

### DIFF
--- a/libs/DXBCParser/DXBCUtils.cpp
+++ b/libs/DXBCParser/DXBCUtils.cpp
@@ -5,6 +5,7 @@
 #include "BlobContainer.h"
 #include "winerror.h"
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include <climits>
 #include <ctype.h>

--- a/libs/DXBCParser/ShaderBinary.h
+++ b/libs/DXBCParser/ShaderBinary.h
@@ -6,6 +6,7 @@
 
 #include "d3d12tokenizedprogramformat.hpp"
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include "minwindef.h"
 


### PR DESCRIPTION
Building using recent Xcode 26 betas fails because of `use of undeclared identifier` errors for `free` and `malloc` in `DXBCUtils.cpp` and `ShaderBinary.h`.