### PR TITLE
chore: Fix building with Meson 1.8.4.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,6 @@ project('dxmt', ['c', 'cpp'], version : 'v0.1', meson_version: '>=1.3.0', defaul
   'cpp_std=c++20', 
   'warning_level=2', 
   'build.cpp_std=c++20',
-  'build.warning_level=2',
   'b_ndebug=if-release',
 ])
 


### PR DESCRIPTION
warning_level is not a per-machine option, and Meson 1.8.4 now errors out with ERROR: Unknown option: "build.warning_level".