### PR TITLE
feat(d3d11): Partially implement shared resource functionality

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -504,7 +504,7 @@ public:
     auto pResource = (D3D11SharedResource*)MapViewOfFile(
       hResource, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(D3D11SharedResource));
 
-    D3D11SharedResource resource = *pResource;
+    D3D11SharedResource resource = std::move(*pResource);
     UnmapViewOfFile(pResource);
     CloseHandle(hResource);
 

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -506,7 +506,6 @@ public:
 
     D3D11SharedResource resource = *pResource;
     UnmapViewOfFile(pResource);
-    CloseHandle(hResource);
 
     if (resource.process != GetCurrentProcess()) {
       ERR("OpenSharedResource: Sharing resources across processes is not yet supported");

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -504,7 +504,7 @@ public:
     auto pResource = (D3D11SharedResource*)MapViewOfFile(
       hResource, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(D3D11SharedResource));
 
-    D3D11SharedResource resource = std::move(*pResource);
+    D3D11SharedResource resource = *pResource;
     UnmapViewOfFile(pResource);
     CloseHandle(hResource);
 

--- a/src/d3d11/d3d11_resource.hpp
+++ b/src/d3d11/d3d11_resource.hpp
@@ -13,6 +13,7 @@
 #include "../d3d10/d3d10_buffer.hpp"
 #include "../d3d10/d3d10_texture.hpp"
 #include "../d3d10/d3d10_view.hpp"
+#include "util_win32_compat.h"
 #include <memory>
 #include <type_traits>
 

--- a/src/d3d11/d3d11_resource.hpp
+++ b/src/d3d11/d3d11_resource.hpp
@@ -159,7 +159,7 @@ GetTexture(ID3D11Resource *pResource) {
 }
 
 struct D3D11SharedResource {
-  D3D11ResourceCommon *d3d11_resource;
+  Com<D3D11ResourceCommon> d3d11_resource;
   HANDLE process;
 
   // FIXME: For a complete implementation of shared resources, consider adding:
@@ -286,7 +286,7 @@ public:
       return E_FAIL;
     }
 
-    handleData->d3d11_resource = static_cast<D3D11ResourceCommon *>(this);
+    handleData->d3d11_resource = Com(static_cast<D3D11ResourceCommon *>(this));
     handleData->process = GetCurrentProcess();
 
     UnmapViewOfFile(handleData);

--- a/src/d3d11/d3d11_resource.hpp
+++ b/src/d3d11/d3d11_resource.hpp
@@ -159,7 +159,7 @@ GetTexture(ID3D11Resource *pResource) {
 }
 
 struct D3D11SharedResource {
-  Com<D3D11ResourceCommon> d3d11_resource;
+  D3D11ResourceCommon *d3d11_resource;
   HANDLE process;
 
   // FIXME: For a complete implementation of shared resources, consider adding:
@@ -286,7 +286,7 @@ public:
       return E_FAIL;
     }
 
-    handleData->d3d11_resource = Com(static_cast<D3D11ResourceCommon *>(this));
+    handleData->d3d11_resource = static_cast<D3D11ResourceCommon *>(this);
     handleData->process = GetCurrentProcess();
 
     UnmapViewOfFile(handleData);

--- a/src/dxgi/dxgi_resource.hpp
+++ b/src/dxgi/dxgi_resource.hpp
@@ -69,8 +69,7 @@ public:
   HRESULT
   STDMETHODCALLTYPE
   GetSharedHandle(HANDLE *pSharedHandle) final {
-    // not supported yet
-    return E_FAIL;
+    return m_resource->GetSharedHandle(pSharedHandle);
   }
 
   HRESULT

--- a/src/util/util_win32_compat.h
+++ b/src/util/util_win32_compat.h
@@ -7,6 +7,8 @@
 #include "log/log.hpp"
 
 #define THREAD_PRIORITY_TIME_CRITICAL 15
+#define FILE_MAP_ALL_ACCESS 0xF001F
+#define PAGE_READWRITE 0x04
 
 inline HANDLE GetCurrentProcess() {
   dxmt::Logger::warn("GetCurrentProcess not implemented.");
@@ -86,6 +88,37 @@ inline BOOL DuplicateHandle(HANDLE   hSourceProcessHandle,
 {
   dxmt::Logger::warn("DuplicateHandle not implemented.");
   return FALSE;
+}
+
+inline HANDLE MapViewOfFile(HANDLE  hFileMappingObject,
+                            DWORD   dwDesiredAccess,
+                            DWORD   dwFileOffsetHigh,
+                            DWORD   dwFileOffsetLow,
+                            SIZE_T dwNumberOfBytesToMap)
+{
+  dxmt::Logger::warn("MapViewOfFile not implemented.");
+  return nullptr;
+}
+
+inline BOOL UnmapViewOfFile(LPCVOID lpBaseAddress) {
+  dxmt::Logger::warn("UnmapViewOfFile not implemented.");
+  return false;
+}
+
+inline HANDLE CreateFileMapping(HANDLE                hFile,
+                                LPSECURITY_ATTRIBUTES lpFileMappingAttributes,
+                                DWORD                 flProtect,
+                                DWORD                 dwMaximumSizeHigh,
+                                DWORD                 dwMaximumSizeLow,
+                                LPCWSTR               lpName)
+{
+  dxmt::Logger::warn("CreateFileMapping not implemented.");
+  return nullptr;
+}
+
+inline DWORD GetLastError(void) {
+  dxmt::Logger::warn("GetLastError not implemented.");
+  return 0;
 }
 
 


### PR DESCRIPTION
This PR adds support for sharing resources within a single process, provided they don't use synchronization (i.e., created without the `D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX` flag).

This fixes video playback in some Unity games that rely on sharing texture data.