### PR TITLE
feat(nvapi): implement stub for NvAPI_Mosaic_GetDisplayViewportsByResolution

### DIFF
--- a/src/nvapi/nvapi.cpp
+++ b/src/nvapi/nvapi.cpp
@@ -509,6 +509,11 @@ NvAPI_GPU_GetPstates20(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_PERF_PSTATES20_I
   return NVAPI_NO_IMPLEMENTATION;
 }
 
+NVAPI_INTERFACE
+NvAPI_Mosaic_GetDisplayViewportsByResolution(NvU32 displayId, NvU32 srcWidth, NvU32 srcHeight, NV_RECT viewports[NV_MOSAIC_MAX_DISPLAYS], NvU8 *bezelCorrected) {
+  return NVAPI_MOSAIC_NOT_ACTIVE;
+}
+
 extern "C" __cdecl void *nvapi_QueryInterface(NvU32 id) {
   switch (id) {
   case 0x0150e828:
@@ -566,6 +571,8 @@ extern "C" __cdecl void *nvapi_QueryInterface(NvU32 id) {
     return (void *)&NvAPI_D3D_GetLatency;
   case 0x6ff81213:
     return (void *)&NvAPI_GPU_GetPstates20;
+  case 0xdc6dc8d3:
+    return (void *)&NvAPI_Mosaic_GetDisplayViewportsByResolution;
   default:
     break;
   }


### PR DESCRIPTION
Added stub for NvAPI_Mosaic_GetDisplayViewportsByResolution https://docs.nvidia.com/gameworks/content/gameworkslibrary/coresdk/nvapi/group__mosaicapi.html#gaa42f70364b56ba5206f1e8c864e368f6

The function is unlikely to ever be implemented.