### PR TITLE
feat(nvapi): added NvAPI_D3D11_IsNvShaderExtnOpCodeSupported opcode semi stub.

### DIFF
--- a/src/nvapi/nvapi.cpp
+++ b/src/nvapi/nvapi.cpp
@@ -140,6 +140,10 @@ NVAPI_INTERFACE NvAPI_D3D11_IsNvShaderExtnOpCodeSupported(
    * UnrealEngine queries it for checking if GPU support time query (NVIDIA-specific workaround)
    */
   case NV_EXTN_OP_SHFL:
+  /*
+   * SOTTR and ROTTR queries it.
+   */
+  case NV_EXTN_OP_FP16_ATOMIC:
     *pSupported = false;
     break;
   default:


### PR DESCRIPTION
Added semi stub NV_EXTN_OP_FP16_ATOMIC opcode for NvAPI_D3D11_IsNvShaderExtnOpCodeSupported.

Rise of the Tomb Raider and Shadow of the Tomb Raider queries it.
