### PR TITLE
feat(nvapi): added few NvAPI_GPU_* stub functions.

### DIFF
--- a/src/nvapi/nvapi.cpp
+++ b/src/nvapi/nvapi.cpp
@@ -70,7 +70,7 @@ NvAPI_GetDisplayDriverVersion(NvDisplayHandle hNvDisplay, NV_DISPLAY_DRIVER_VERS
 
 NVAPI_INTERFACE
 NvAPI_GetInterfaceVersionString(NvAPI_ShortString szDesc) {
-  std::string version_str = std::format("NVAPI Open Source Interface (DXMT-NVAPI)");
+  std::string version_str = "NVAPI Open Source Interface (DXMT-NVAPI)";
 
   if (!szDesc)
     return NVAPI_INVALID_ARGUMENT;
@@ -88,7 +88,6 @@ NvAPI_D3D_GetCurrentSLIState(IUnknown *pDevice,
 
   switch (pSliState->version) {
   case NV_GET_CURRENT_SLI_STATE_VER1:
-
     pSliState->maxNumAFRGroups = 1;
     pSliState->numAFRGroups = 1;
     pSliState->currentAFRIndex = 0;
@@ -482,6 +481,51 @@ NvAPI_GPU_GetConnectedDisplayIds(
 }
 
 NVAPI_INTERFACE
+NvAPI_GPU_GetAllClockFrequencies(__in NvPhysicalGpuHandle hPhysicalGPU,
+                                 __inout NV_GPU_CLOCK_FREQUENCIES *pClkFreqs) {
+  if (!pClkFreqs)
+    return NVAPI_INVALID_ARGUMENT;
+
+  return NVAPI_NOT_SUPPORTED;
+}
+
+NVAPI_INTERFACE
+NvAPI_GPU_GetGpuCoreCount(NvPhysicalGpuHandle hPhysicalGpu, NvU32 *pCount) {
+  if (!pCount)
+    return NVAPI_INVALID_ARGUMENT;
+
+  return NVAPI_NOT_SUPPORTED;
+}
+
+NVAPI_INTERFACE
+NvAPI_GPU_GetBusId(NvPhysicalGpuHandle hPhysicalGpu, NvU32 *pBusId) {
+  if (!pBusId)
+    return NVAPI_INVALID_ARGUMENT;
+
+  return NVAPI_NOT_SUPPORTED;
+}
+
+NVAPI_INTERFACE
+NvAPI_GPU_GetMemoryInfo(NvPhysicalGpuHandle hPhysicalGpu, NV_DISPLAY_DRIVER_MEMORY_INFO *pMemoryInfo) {
+  if (!pMemoryInfo)
+    return NVAPI_INVALID_ARGUMENT;
+
+  return NVAPI_NOT_SUPPORTED;
+}
+
+NVAPI_INTERFACE
+NvAPI_GPU_GetFullName(NvPhysicalGpuHandle hPhysicalGpu, NvAPI_ShortString szName) {
+  std::string adapter_str = "NVIDIA GeForce RTX";
+
+  if (!szName)
+    return NVAPI_INVALID_ARGUMENT;
+
+  memcpy(szName, adapter_str.c_str(), adapter_str.size());
+
+  return NVAPI_OK;
+}
+
+NVAPI_INTERFACE
 NvAPI_DISP_GetGDIPrimaryDisplayId(NvU32 *displayId) {
   if (!displayId)
     return NVAPI_INVALID_ARGUMENT;
@@ -589,6 +633,19 @@ NvAPI_Stereo_SetDriverMode(NV_STEREO_DRIVER_MODE mode) {
   return NVAPI_STEREO_NOT_INITIALIZED;
 }
 
+NVAPI_INTERFACE
+NvAPI_DRS_CreateSession(NvDRSSessionHandle *phSession) {
+  if (!phSession)
+    return NVAPI_INVALID_ARGUMENT;
+
+  return NVAPI_NOT_SUPPORTED;
+}
+
+NVAPI_INTERFACE
+NvAPI_DRS_LoadSettings(NvDRSSessionHandle hSession) {
+  return NVAPI_NOT_SUPPORTED;
+}
+
 extern "C" __cdecl void *nvapi_QueryInterface(NvU32 id) {
   switch (id) {
   case 0x0150e828:
@@ -647,6 +704,18 @@ extern "C" __cdecl void *nvapi_QueryInterface(NvU32 id) {
     return (void *)&NvAPI_GPU_GetConnectedDisplayIds;
   case 0x1e9d8a31:
     return (void *)&NvAPI_DISP_GetGDIPrimaryDisplayId;
+  case 0xdcb616c3:
+    return (void *)&NvAPI_GPU_GetAllClockFrequencies;
+  case 0xc7026a87:
+    return (void *)&NvAPI_GPU_GetGpuCoreCount;
+  case 0x1be0b8e5:
+    return (void *)&NvAPI_GPU_GetBusId;
+  case 0x07f9b368:
+    return (void *)&NvAPI_GPU_GetMemoryInfo;
+  case 0xceee8e9f:
+    return (void *)&NvAPI_GPU_GetFullName;
+  case 0x6ff81213:
+    return (void *)&NvAPI_GPU_GetPstates20;
   case 0xaef96ca1:
     return (void *)&NvAPI_D3D_GetSleepStatus;
   case 0xac1ca9e0:
@@ -657,14 +726,16 @@ extern "C" __cdecl void *nvapi_QueryInterface(NvU32 id) {
     return (void *)&NvAPI_D3D_Sleep;
   case 0x1a587f9c:
     return (void *)&NvAPI_D3D_GetLatency;
-  case 0x6ff81213:
-    return (void *)&NvAPI_GPU_GetPstates20;
   case 0xdc6dc8d3:
     return (void *)&NvAPI_Mosaic_GetDisplayViewportsByResolution;
   case 0x348ff8e1:
     return (void *)&NvAPI_Stereo_IsEnabled;
   case 0x5e8f0bec:
     return (void *)&NvAPI_Stereo_SetDriverMode;
+  case 0x0694d52e:
+    return (void *)&NvAPI_DRS_CreateSession;
+  case 0x375dbd6b:
+    return (void *)&NvAPI_DRS_LoadSettings;
   default:
     break;
   }


### PR DESCRIPTION
Added stubs used by `Dishonored 2` and `Dishonored: Death of the Outsider` games:
- NvAPI_GPU_GetAllClockFrequencies
- NvAPI_GPU_GetGpuCoreCount
- NvAPI_GPU_GetBusId
- NvAPI_GPU_GetMemoryInfo (deprecated API)

Added implementation for NvAPI_GPU_GetFullName.

Added stubs used by `God of War` and `Steam`:
- NvAPI_DRS_CreateSession
- NvAPI_DRS_LoadSettings

