### PR TITLE
fix(d3d11): make backbuffer bindable shader resource only when requested

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -140,8 +140,9 @@ public:
       .MiscFlags = {},
       .TextureLayout = {},
     };
-    // if (desc_.BufferUsage & DXGI_USAGE_SHADER_INPUT)
-    backbuffer_desc_.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+    
+    if (desc_.BufferUsage & DXGI_USAGE_SHADER_INPUT)
+      backbuffer_desc_.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
     if (desc_.BufferUsage & DXGI_USAGE_UNORDERED_ACCESS)
       backbuffer_desc_.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
 


### PR DESCRIPTION
uncomments the already present check. it doesn't seem to break anything & behaviour is consistent with what dxvk does. win d3d11 also requires bitblt model swap effect to be used but don't think it actually matters for us