### PR TITLE
feat(nvapi): added NvAPI_D3D_SetVerticalSyncMode stub

### DIFF
--- a/src/nvapi/nvapi.cpp
+++ b/src/nvapi/nvapi.cpp
@@ -681,6 +681,14 @@ NvAPI_D3D_GetLatency(IUnknown *pDev, NV_LATENCY_RESULT_PARAMS *pGetLatencyParams
 }
 
 NVAPI_INTERFACE
+NvAPI_D3D_SetVerticalSyncMode(IUnknown *pDev, NVAPI_VSYNC_MODE vsyncMode) {
+  if (!pDev)
+    return NVAPI_INVALID_ARGUMENT;
+
+  return NVAPI_NO_IMPLEMENTATION;
+}
+
+NVAPI_INTERFACE
 NvAPI_GPU_GetPstates20(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_PERF_PSTATES20_INFO *pPstatesInfo) {
   if (!hPhysicalGpu || !pPstatesInfo)
     return NVAPI_INVALID_ARGUMENT;
@@ -807,6 +815,8 @@ extern "C" __cdecl void *nvapi_QueryInterface(NvU32 id) {
     return (void *)&NvAPI_D3D_Sleep;
   case 0x1a587f9c:
     return (void *)&NvAPI_D3D_GetLatency;
+  case 0x5526cfd1:
+    return (void *)&NvAPI_D3D_SetVerticalSyncMode;
   case 0xdc6dc8d3:
     return (void *)&NvAPI_Mosaic_GetDisplayViewportsByResolution;
   case 0x348ff8e1:


### PR DESCRIPTION
NvAPI_D3D_SetVerticalSyncMode is documented as not supported from Win10+

It's used by `Titanfall 2`, however it's always called with sync off.
Game control vsync by `D3D11SwapChain::Present1()` with `SyncInterval` `0` or `1`