### PR TITLE
Update to_metal_swizzle to a static inline

### DIFF
--- a/src/winemetal/unix/winemetal_unix.c
+++ b/src/winemetal/unix/winemetal_unix.c
@@ -301,7 +301,7 @@ _MTLBuffer_newTexture(void *obj) {
   return STATUS_SUCCESS;
 }
 
-inline MTLTextureSwizzleChannels
+static inline MTLTextureSwizzleChannels
 to_metal_swizzle(struct WMTTextureSwizzleChannels swizzle, enum WMTPixelFormat format) {
   if (format & WMTPixelFormatRGB1Swizzle) {
     return MTLTextureSwizzleChannelsMake(


### PR DESCRIPTION
Otherwise compile fails with: 
Undefined symbols for architecture x86_64:
  "_to_metal_swizzle", referenced from:
      __MTLTexture_newTextureView in winemetal_unix.c.o