### PR TITLE
Timestamp Query

### DIFF
--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -331,11 +331,16 @@ public:
     D3D11_QUERY_DESC desc;
     ((ID3D11Query *)pAsync)->GetDesc(&desc);
     switch (desc.Query) {
-    case D3D11_QUERY_TIMESTAMP:
     case D3D11_QUERY_EVENT:
+    case D3D11_QUERY_TIMESTAMP_DISJOINT:
       promote_flush = true;
       ctx_state.current_cmdlist->issued_event_query.push_back(static_cast<MTLD3D11EventQuery *>(pAsync));
       break;
+    case D3D11_QUERY_TIMESTAMP: {
+      promote_flush = true;
+      ctx_state.current_cmdlist->issued_timestamp_query.push_back(static_cast<MTLD3D11TimestampQuery *>(pAsync));
+      break;
+    }
     case D3D11_QUERY_OCCLUSION:
     case D3D11_QUERY_OCCLUSION_PREDICATE: {
       auto building_query = ctx_state.building_visibility_queries.find(pAsync);
@@ -354,7 +359,6 @@ public:
       ctx_state.building_visibility_queries.erase(building_query);
       break;
     }
-    case D3D11_QUERY_TIMESTAMP_DISJOINT:
     case D3D11_QUERY_PIPELINE_STATISTICS: {
       // ignore
       break;

--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -19,7 +19,7 @@ struct DeferredContextInternalState {
   Com<MTLD3D11CommandList> current_cmdlist;
   std::unordered_map<DynamicBuffer *, DynamicBufferAllocation> current_dynamic_buffer_allocations;
   std::unordered_map<DynamicLinearTexture *, std::pair<TextureAllocation *, uint32_t>> current_dynamic_texture_allocations;
-  std::unordered_map<void *, std::pair<Com<IMTLD3DOcclusionQuery>, uint32_t>> building_visibility_queries;
+  std::unordered_map<void *, std::pair<Com<MTLD3D11OcclusionQuery>, uint32_t>> building_visibility_queries;
 };
 
 template<typename Object> Rc<Object> forward_rc(Rc<Object>& obj) {
@@ -280,6 +280,9 @@ public:
   void
   STDMETHODCALLTYPE
   Begin(ID3D11Asynchronous *pAsync) override {
+    if (unlikely(!pAsync))
+      return;
+
     D3D11_QUERY_DESC desc;
     ((ID3D11Query *)pAsync)->GetDesc(&desc);
     switch (desc.Query) {
@@ -304,7 +307,7 @@ public:
         enc.beginVisibilityResultQuery(enc.currentDeferredVisibilityQuery(query_id));
       });
       ctx_state.building_visibility_queries.insert(
-          {(void *)pAsync, {static_cast<IMTLD3DOcclusionQuery *>(pAsync), query_id}}
+          {(void *)pAsync, {static_cast<MTLD3D11OcclusionQuery *>(pAsync), query_id}}
       );
       break;
     }
@@ -322,6 +325,9 @@ public:
   void
   STDMETHODCALLTYPE
   End(ID3D11Asynchronous *pAsync) override {
+    if (unlikely(!pAsync))
+      return;
+
     D3D11_QUERY_DESC desc;
     ((ID3D11Query *)pAsync)->GetDesc(&desc);
     switch (desc.Query) {

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -350,7 +350,6 @@ public:
     D3D11_QUERY_DESC desc;
     ((ID3D11Query *)pAsync)->GetDesc(&desc);
     switch (desc.Query) {
-    case D3D11_QUERY_TIMESTAMP:
     case D3D11_QUERY_TIMESTAMP_DISJOINT:
     case D3D11_QUERY_EVENT: {
       if (ctx_state.has_dirty_op_since_last_event) {
@@ -364,6 +363,16 @@ public:
         ctx_state.has_dirty_op_since_last_event = false;
       } else {
         static_cast<MTLD3D11EventQuery *>(pAsync)->Issue(cmd_queue.GetCurrentEventSeqId());
+      }
+      break;
+    }
+    case D3D11_QUERY_TIMESTAMP: {
+      if (auto query = static_cast<MTLD3D11TimestampQuery *>(pAsync)->End()) {
+        InvalidateCurrentPass(true);
+        EmitOP([query = Rc(query)](ArgumentEncodingContext &enc) mutable {
+          enc.sampleTimestamp(std::move(query));
+        });
+        promote_flush = true;
       }
       break;
     }
@@ -402,7 +411,6 @@ public:
     ((ID3D11Query *)pAsync)->GetDesc(&desc);
     switch (desc.Query) {
     case D3D11_QUERY_EVENT:
-    case D3D11_QUERY_TIMESTAMP:
     case D3D11_QUERY_TIMESTAMP_DISJOINT: {
       switch (static_cast<MTLD3D11EventQuery *>(pAsync)->CheckEventState(cmd_queue.SignaledEventSeqId())) {
       case EventState::Pending:
@@ -440,8 +448,9 @@ public:
       break;
     }
     case D3D11_QUERY_TIMESTAMP: {
-      if (pData)
-        *static_cast<UINT64 *>(pData) = 0;
+      uint64_t null_data;
+      uint64_t *data_ptr = pData ? (uint64_t *)pData : &null_data;
+      hr = static_cast<MTLD3D11TimestampQuery *>(pAsync)->GetData(data_ptr);
       break;
     }
     case D3D11_QUERY_TIMESTAMP_DISJOINT: {
@@ -502,6 +511,10 @@ public:
     }
 
     for (const auto &query : cmdlist->issued_event_query) {
+      End(query.ptr());
+    }
+
+    for (const auto &query : cmdlist->issued_timestamp_query) {
       End(query.ptr());
     }
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -306,6 +306,9 @@ public:
   void
   STDMETHODCALLTYPE
   Begin(ID3D11Asynchronous *pAsync) override {
+    if (unlikely(!pAsync))
+      return;
+
     std::lock_guard<d3d11_device_mutex> lock(mutex);
 
     // in theory pAsync could be any of them: { Query, Predicate, Counter }.
@@ -319,10 +322,9 @@ public:
       break;
     case D3D11_QUERY_OCCLUSION:
     case D3D11_QUERY_OCCLUSION_PREDICATE: {
-      auto query = static_cast<IMTLD3DOcclusionQuery *>(pAsync);
-      if (query->Begin())
-        EmitST([query_ = query->__query()](ArgumentEncodingContext &enc) mutable {
-          enc.beginVisibilityResultQuery(std::move(query_));
+      if (auto query = static_cast<MTLD3D11OcclusionQuery *>(pAsync)->Begin())
+        EmitST([query = Rc(query)](ArgumentEncodingContext &enc) mutable {
+          enc.beginVisibilityResultQuery(std::move(query));
         });
       break;
     }
@@ -340,6 +342,9 @@ public:
   void
   STDMETHODCALLTYPE
   End(ID3D11Asynchronous *pAsync) override {
+    if (unlikely(!pAsync))
+      return;
+
     std::lock_guard<d3d11_device_mutex> lock(mutex);
 
     D3D11_QUERY_DESC desc;
@@ -364,10 +369,9 @@ public:
     }
     case D3D11_QUERY_OCCLUSION:
     case D3D11_QUERY_OCCLUSION_PREDICATE: {
-      auto query = static_cast<IMTLD3DOcclusionQuery *>(pAsync);
-      if (query->End())
-        EmitST([qeury_ = query->__query()](ArgumentEncodingContext &enc) mutable {
-          enc.endVisibilityResultQuery(std::move(qeury_));
+      if (auto query = static_cast<MTLD3D11OcclusionQuery *>(pAsync)->End())
+        EmitST([query = Rc(query)](ArgumentEncodingContext &enc) mutable {
+          enc.endVisibilityResultQuery(std::move(query));
         });
       promote_flush = true;
       break;
@@ -426,13 +430,13 @@ public:
     case D3D11_QUERY_OCCLUSION: {
       uint64_t null_data;
       uint64_t *data_ptr = pData ? (uint64_t *)pData : &null_data;
-      hr = ((IMTLD3DOcclusionQuery *)pAsync)->GetData(data_ptr);
+      hr = static_cast<MTLD3D11OcclusionQuery *>(pAsync)->GetData(data_ptr);
       break;
     }
     case D3D11_QUERY_OCCLUSION_PREDICATE: {
       BOOL null_data;
       BOOL *data_ptr = pData ? (BOOL *)pData : &null_data;
-      hr = ((IMTLD3DOcclusionQuery *)pAsync)->GetData(data_ptr);
+      hr = static_cast<MTLD3D11OcclusionQuery *>(pAsync)->GetData(data_ptr);
       break;
     }
     case D3D11_QUERY_TIMESTAMP: {
@@ -494,7 +498,7 @@ public:
     auto query_list = AllocateCommandData<Rc<VisibilityResultQuery>>(cmdlist->visibility_query_count);
     for (const auto &[query, index] : cmdlist->issued_visibility_query) {
       query_list[index] = new VisibilityResultQuery();
-      query->DoDeferredQuery(query_list[index]);
+      query->DoDeferredQuery(query_list[index].ptr());
     }
 
     for (const auto &query : cmdlist->issued_event_query) {
@@ -594,7 +598,7 @@ public:
   }
 
 private:
-  std::vector<Com<IMTLD3DOcclusionQuery>> pending_occlusion_queries;
+  std::vector<Com<MTLD3D11OcclusionQuery>> pending_occlusion_queries;
   CommandQueue &cmd_queue;
   ContextInternalState ctx_state;
   std::atomic<uint32_t> refcount = 0;

--- a/src/d3d11/d3d11_context_impl.cpp
+++ b/src/d3d11/d3d11_context_impl.cpp
@@ -5105,6 +5105,7 @@ public:
     visibility_query_count = 0;
     issued_visibility_query.clear();
     issued_event_query.clear();
+    issued_timestamp_query.clear();
     list.reset();
     staging_allocator.free_blocks(~0uLL);
     cpu_command_allocator.free_blocks(~0uLL);
@@ -5188,6 +5189,7 @@ public:
   uint32_t visibility_query_count = 0;
   std::vector<std::pair<Com<MTLD3D11OcclusionQuery>, uint32_t>> issued_visibility_query;
   std::vector<Com<MTLD3D11EventQuery>> issued_event_query;
+  std::vector<Com<MTLD3D11TimestampQuery>> issued_timestamp_query;
 
 private:
   UINT context_flag;

--- a/src/d3d11/d3d11_context_impl.cpp
+++ b/src/d3d11/d3d11_context_impl.cpp
@@ -5186,7 +5186,7 @@ public:
   std::vector<Rc<StagingResource>> read_staging_resources;
   std::vector<Rc<StagingResource>> written_staging_resources;
   uint32_t visibility_query_count = 0;
-  std::vector<std::pair<Com<IMTLD3DOcclusionQuery>, uint32_t>> issued_visibility_query;
+  std::vector<std::pair<Com<MTLD3D11OcclusionQuery>, uint32_t>> issued_visibility_query;
   std::vector<Com<MTLD3D11EventQuery>> issued_event_query;
 
 private:

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -434,8 +434,7 @@ public:
     case D3D11_QUERY_OCCLUSION_PREDICATE:
       return CreateOcculusionQuery(this, pQueryDesc, ppQuery);
     case D3D11_QUERY_TIMESTAMP:
-      *ppQuery = ref(new MTLD3D11EventQueryImpl<UINT64>(this, pQueryDesc));
-      return S_OK;
+      return CreateTimestampQuery(this, pQueryDesc, ppQuery);
     case D3D11_QUERY_TIMESTAMP_DISJOINT: {
       *ppQuery = ref(new MTLD3D11EventQueryImpl<D3D11_QUERY_DATA_TIMESTAMP_DISJOINT>(this, pQueryDesc));
       return S_OK;

--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -3,13 +3,13 @@
 
 namespace dxmt {
 
-class OcculusionQuery : public MTLD3DQueryBase<IMTLD3DOcclusionQuery> {
-  using MTLD3DQueryBase<IMTLD3DOcclusionQuery>::MTLD3DQueryBase;
+class OcculusionQuery : public MTLD3DQueryBase<MTLD3D11OcclusionQuery> {
+  using MTLD3DQueryBase<MTLD3D11OcclusionQuery>::MTLD3DQueryBase;
 
-  QueryState state = QueryState::Signaled;
+  QueryState state_ = QueryState::Signaled;
 
-  Rc<VisibilityResultQuery> query = new VisibilityResultQuery();
-  uint64_t accumulated_value = 0;
+  Rc<VisibilityResultQuery> query_ = new VisibilityResultQuery();
+  uint64_t accumulated_value_ = 0;
 
   virtual UINT STDMETHODCALLTYPE
   GetDataSize() override {
@@ -18,62 +18,58 @@ class OcculusionQuery : public MTLD3DQueryBase<IMTLD3DOcclusionQuery> {
 
   virtual HRESULT
   GetData(void *data) override {
-    if (state == QueryState::Building) {
+    if (state_ == QueryState::Building) {
       return DXGI_ERROR_INVALID_CALL;
     }
-    if (state == QueryState::Signaled || query->getValue(&accumulated_value)) {
+    if (state_ == QueryState::Signaled || query_->getValue(&accumulated_value_)) {
       if (desc_.Query == D3D11_QUERY_OCCLUSION_PREDICATE) {
-        *((BOOL *)data) = accumulated_value != 0;
+        *((BOOL *)data) = accumulated_value_ != 0;
       } else {
-        *((uint64_t *)data) = accumulated_value;
+        *((uint64_t *)data) = accumulated_value_;
       }
-      query = new VisibilityResultQuery();
-      state = QueryState::Signaled;
+      query_ = new VisibilityResultQuery();
+      state_ = QueryState::Signaled;
       return S_OK;
     }
     return S_FALSE;
   }
 
-  virtual bool
+  virtual VisibilityResultQuery *
   Begin() override {
-    if (state == QueryState::Signaled) {
-      state = QueryState::Building;
-      return true;
+    if (state_ == QueryState::Signaled) {
+      state_ = QueryState::Building;
+      return query_.ptr();
     }
-    if (state == QueryState::Issued) {
+    if (state_ == QueryState::Issued) {
       // discard previous issued query
-      state = QueryState::Building;
-      query = new VisibilityResultQuery();
-      return true;
+      state_ = QueryState::Building;
+      query_ = new VisibilityResultQuery();
+      return query_.ptr();
     }
     // FIXME: it's effectively ignoring  Begin() after Begin()
-    return false;
+    return nullptr;
   };
 
-  virtual bool
+  virtual VisibilityResultQuery *
   End() override {
-    if (state == QueryState::Signaled) {
+    if (state_ == QueryState::Signaled) {
       // ignore  a single End()
-      accumulated_value = 0;
-      return false;
+      accumulated_value_ = 0;
+      return nullptr;
     }
-    if (state == QueryState::Issued) {
+    if (state_ == QueryState::Issued) {
       // FIXME: it's effectively ignoring End() after End()
-      return false;
+      return nullptr;
     }
-    state = QueryState::Issued;
-    return true;
+    state_ = QueryState::Issued;
+    return query_.ptr();
   };
 
-  virtual void DoDeferredQuery(dxmt::Rc<dxmt::VisibilityResultQuery> &deferred_query) override{
-    accumulated_value = 0;
-    state = QueryState::Issued;
-    query = deferred_query;
+  virtual void DoDeferredQuery(VisibilityResultQuery *deferred_query) override{
+    accumulated_value_ = 0;
+    state_ = QueryState::Issued;
+    query_ = deferred_query;
   };
-
-  virtual Rc<VisibilityResultQuery> __query() override {
-    return query;
-  }
 };
 
 HRESULT

--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -81,4 +81,48 @@ CreateOcculusionQuery(MTLD3D11Device *pDevice, const D3D11_QUERY_DESC *pDesc, ID
   return S_FALSE;
 }
 
+class MTLD3D11TimestampQueryImpl : public MTLD3DQueryBase<MTLD3D11TimestampQuery> {
+  using MTLD3DQueryBase<MTLD3D11TimestampQuery>::MTLD3DQueryBase;
+
+  QueryState state_ = QueryState::Signaled;
+
+  Rc<TimestampQuery> query_ = new TimestampQuery();
+  uint64_t latest_value_ = 0;
+
+  virtual UINT STDMETHODCALLTYPE
+  GetDataSize() override {
+    return sizeof(UINT64);
+  };
+
+  virtual HRESULT
+  GetData(void *data) override {
+    if (state_ == QueryState::Signaled || query_->getValue(&latest_value_)) {
+      *((uint64_t *)data) = latest_value_;
+      query_ = new TimestampQuery();
+      state_ = QueryState::Signaled;
+      return S_OK;
+    }
+    return S_FALSE;
+  }
+
+  virtual TimestampQuery *
+  End() override {
+    if (state_ == QueryState::Issued) {
+      // discard previous query
+      query_ = new TimestampQuery();
+    }
+    state_ = QueryState::Issued;
+    return query_.ptr();
+  };
+};
+
+HRESULT
+CreateTimestampQuery(MTLD3D11Device *pDevice, const D3D11_QUERY_DESC *pDesc, ID3D11Query **ppQuery) {
+  if (ppQuery) {
+    *ppQuery = ref(new MTLD3D11TimestampQueryImpl(pDevice, pDesc));
+    return S_OK;
+  }
+  return S_FALSE;
+}
+
 } // namespace dxmt

--- a/src/d3d11/d3d11_query.hpp
+++ b/src/d3d11/d3d11_query.hpp
@@ -165,4 +165,14 @@ HRESULT CreateOcculusionQuery(MTLD3D11Device *pDevice,
                               const D3D11_QUERY_DESC *pDesc,
                               ID3D11Query **ppQuery);
 
+class MTLD3D11TimestampQuery : public ID3D11Query {
+public:
+  virtual HRESULT GetData(void *data) = 0;
+  virtual TimestampQuery *End() = 0;
+};
+
+HRESULT CreateTimestampQuery(MTLD3D11Device *pDevice,
+                              const D3D11_QUERY_DESC *pDesc,
+                              ID3D11Query **ppQuery);
+
 } // namespace dxmt

--- a/src/d3d11/d3d11_query.hpp
+++ b/src/d3d11/d3d11_query.hpp
@@ -5,17 +5,6 @@
 #include "log/log.hpp"
 #include "../d3d10/d3d10_query.hpp"
 
-DEFINE_COM_INTERFACE("a301e56d-d87e-4b69-8440-bd003e285904",
-                     IMTLD3DOcclusionQuery)
-    : public ID3D11Query {
-  virtual HRESULT GetData(void *data) = 0;
-  virtual bool Begin() = 0;
-  virtual bool End() = 0;
-  virtual void DoDeferredQuery(dxmt::Rc<dxmt::VisibilityResultQuery> &deferred_query) = 0;
-
-  virtual dxmt::Rc<dxmt::VisibilityResultQuery> __query() = 0;
-};
-
 namespace dxmt {
 
 template <typename Query>
@@ -162,6 +151,14 @@ private:
   QueryState state = QueryState::Undefined;
   uint32_t stall_counter = 0;
   uint64_t should_be_signaled_at = 0;
+};
+
+class MTLD3D11OcclusionQuery : public ID3D11Query {
+public:
+  virtual HRESULT GetData(void *data) = 0;
+  virtual VisibilityResultQuery *Begin() = 0;
+  virtual VisibilityResultQuery *End() = 0;
+  virtual void DoDeferredQuery(VisibilityResultQuery *deferred_query) = 0;
 };
 
 HRESULT CreateOcculusionQuery(MTLD3D11Device *pDevice,

--- a/src/dxmt/dxmt_command_queue.hpp
+++ b/src/dxmt/dxmt_command_queue.hpp
@@ -96,7 +96,7 @@ public:
     list_enc.execute(enc);
     attached_cmdbuf = cmdbuf;
     auto t1 = clock::now();
-    visibility_readback = enc.flushCommands(cmdbuf, chunk_id, chunk_event_id);
+    readback = enc.flushCommands(cmdbuf, chunk_id, chunk_event_id);
     auto t2 = clock::now();
     statistics.encode_prepare_interval += (t1 - t0);
     statistics.encode_flush_interval += (t2 - t1);
@@ -106,7 +106,7 @@ public:
   uint64_t chunk_event_id;
   uint64_t frame_;
   uint64_t signal_frame_latency_fence_;
-  std::unique_ptr<VisibilityResultReadback> visibility_readback;
+  QueryReadbacks readback;
   uint64_t resource_initializer_event_id;
 
 private:
@@ -124,7 +124,7 @@ public:
   void
   reset() noexcept {
     signal_frame_latency_fence_ = ~0ull;
-    visibility_readback = {};
+    readback = {};
     list_enc.reset();
     ref_tracker.clear();
     attached_cmdbuf = nullptr;

--- a/src/dxmt/dxmt_context.cpp
+++ b/src/dxmt/dxmt_context.cpp
@@ -689,7 +689,7 @@ ArgumentEncodingContext::$$setEncodingContext(uint64_t seq_id, uint64_t frame_id
 
 constexpr unsigned kEncoderOptimizerThreshold = 64;
 
-std::unique_ptr<VisibilityResultReadback>
+QueryReadbacks
 ArgumentEncodingContext::flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId, uint64_t event_seq_id) {
   assert(!encoder_current);
 
@@ -722,10 +722,10 @@ ArgumentEncodingContext::flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId
     }
   }
 
-  std::unique_ptr<VisibilityResultReadback> visibility_readback {};
+  QueryReadbacks readbacks{};
 
   if (auto count = vro_state_.reset()) {
-    visibility_readback = std::make_unique<VisibilityResultReadback>(
+    readbacks.visibility = std::make_unique<VisibilityResultReadback>(
         device_, seqId, count, pending_queries_
     );
   }
@@ -784,8 +784,8 @@ ArgumentEncodingContext::flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId
         render_pass_info.render_target_height = data->render_target_height;
       }
       if (data->use_visibility_result) {
-        assert(visibility_readback);
-        render_pass_info.visibility_buffer = visibility_readback->visibility_result_heap;
+        assert(readbacks.visibility);
+        render_pass_info.visibility_buffer = readbacks.visibility->visibility_result_heap;
       }
       auto gpu_buffer_ = data->allocated_argbuf;
       auto encoder = cmdbuf.renderCommandEncoder(render_pass_info);
@@ -999,7 +999,7 @@ ArgumentEncodingContext::flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId
     }
   }
 
-  return visibility_readback;
+  return readbacks;
 }
 
 DXMT_ENCODER_LIST_OP

--- a/src/dxmt/dxmt_context.cpp
+++ b/src/dxmt/dxmt_context.cpp
@@ -16,6 +16,7 @@ ArgumentEncodingContext::ArgumentEncodingContext(CommandQueue &queue, WMT::Devic
     blit_depth_stencil_cmd(device, lib, *this),
     clear_res_cmd(device, lib, *this),
     mv_scale_cmd(device, lib, *this),
+    timestamp_state_(device),
     device_(device),
     queue_(queue) {
   dummy_sampler_info_.support_argument_buffers = true;
@@ -41,6 +42,7 @@ ArgumentEncodingContext::ArgumentEncodingContext(CommandQueue &queue, WMT::Devic
   dummy_cbuffer_ = device.newBuffer(dummy_cbuffer_info_);
   std::memset(dummy_cbuffer_info_.memory.get(), 0, 65536);
   cpu_buffer_chunks_.emplace_back();
+  barrier_event_ = device_.newEvent();
 };
 
 ArgumentEncodingContext::~ArgumentEncodingContext() {
@@ -679,6 +681,25 @@ ArgumentEncodingContext::currentFrameStatistics() {
 }
 
 void
+ArgumentEncodingContext::sampleTimestamp(Rc<TimestampQuery> &&query) {
+  assert(!encoder_current);
+  if (encoder_last && encoder_last->type == EncoderType::SampleTimestamp) {
+    timestamp_state_.coalaseQuery(query.ptr());
+    static_cast<SampleTimestampData *>(encoder_last)->queries.push_back(std::move(query));
+    return;
+  }
+  auto encoder_info = allocate<SampleTimestampData>();
+  encoder_info->type = EncoderType::SampleTimestamp;
+  encoder_info->id = nextEncoderId();
+  encoder_info->readback_index = timestamp_state_.addQuery(query.ptr());
+  encoder_info->queries = {};
+  encoder_info->queries.push_back(std::move(query));
+
+  encoder_current = encoder_info;
+  endPass();
+}
+
+void
 ArgumentEncodingContext::$$setEncodingContext(uint64_t seq_id, uint64_t frame_id) {
   current_buffer_chunk_ = 0;
   cpu_buffer_ = cpu_buffer_chunks_[current_buffer_chunk_].ptr;
@@ -730,6 +751,8 @@ ArgumentEncodingContext::flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId
     );
   }
   std::erase_if(pending_queries_, [=](auto &query) -> bool { return query->queryEndAt() == seqId; });
+
+  readbacks.timestamp = timestamp_state_.flush(cmdbuf);
 
   while (encoder_index) {
     auto current = encoders[encoder_count - encoder_index];
@@ -982,6 +1005,44 @@ ArgumentEncodingContext::flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId
       data->~TemporalUpscaleData();
       break;
     }
+    case EncoderType::SampleTimestamp: {
+      auto data = static_cast<SampleTimestampData *>(current);
+      if (auto readback = readbacks.timestamp.get(); readback->sampleBuffer()) {
+
+        /**
+        Since Metal driver may change the execution order of encoders, implement a "barrier" to prevent that
+        FIXME: Not an elegant implementation, should get rid of it when fence-based synchronization is done
+        */
+        barrierOnQueue(cmdbuf);
+
+        WMTSampleBufferAttachmentInfo sample_buffer_info{};
+        sample_buffer_info.sample_buffer = readback->sampleBuffer();
+        sample_buffer_info.start_of_encoder_sample_index = data->readback_index;
+        sample_buffer_info.end_of_encoder_sample_index = ~0ull; /* MTLCounterDontSample */
+        auto encoder = cmdbuf.blitCommandEncoderWithSampleBuffers(&sample_buffer_info, 1);
+        encoder.setLabel(WMT::String::string("SampleTimestamp", WMTUTF8StringEncoding));
+        {
+          /**
+          `sampleBufferAttachments` does not work when the blit encoder is empty, just do something
+          FIXME: potential perf overhead? 
+          */
+          struct wmtcmd_blit_fillbuffer fill;
+          fill.next.set(nullptr);
+          fill.type = WMTBlitCommandFillBuffer;
+          fill.buffer = dummy_cbuffer_;
+          fill.offset = 0;
+          fill.length = 4;
+          fill.value = 0;
+          MTLBlitCommandEncoder_encodeCommands(encoder, (const struct wmtcmd_base *)&fill);
+        }
+        encoder.endEncoding();
+
+      } else {
+        // Use timestamp from command buffer's `gpuEndTime`
+      }
+      data->~SampleTimestampData();
+      break;
+    }
     default:
       break;
     }
@@ -1015,6 +1076,10 @@ ArgumentEncodingContext::checkEncoderRelation(EncoderData *former, EncoderData *
   if (former->type == EncoderType::WaitForEvent)
     return DXMT_ENCODER_LIST_OP_SYNCHRONIZE;
   if (latter->type == EncoderType::WaitForEvent)
+    return DXMT_ENCODER_LIST_OP_SYNCHRONIZE;
+  if (former->type == EncoderType::SampleTimestamp)
+    return DXMT_ENCODER_LIST_OP_SYNCHRONIZE;
+  if (latter->type == EncoderType::SampleTimestamp)
     return DXMT_ENCODER_LIST_OP_SYNCHRONIZE;
 
   while (former->type != latter->type) {

--- a/src/dxmt/dxmt_context.hpp
+++ b/src/dxmt/dxmt_context.hpp
@@ -88,6 +88,7 @@ enum class EncoderType {
   SignalEvent,
   TemporalUpscale,
   WaitForEvent,
+  SampleTimestamp,
 };
 
 struct EncoderData {
@@ -231,6 +232,12 @@ struct SignalEventData : EncoderData {
 struct WaitForEventData : EncoderData {
   WMT::Reference<WMT::Event> event;
   uint64_t value;
+};
+
+struct SampleTimestampData: EncoderData {
+  uint64_t readback_index;
+  // TODO: small_vector opt
+  std::vector<Rc<TimestampQuery>> queries;
 };
 
 struct TemporalUpscaleData : EncoderData {
@@ -705,6 +712,14 @@ public:
     return deferred_visibility_query_stack_.back()[query_id];
   }
 
+  void sampleTimestamp(Rc<TimestampQuery> &&query);
+
+  void barrierOnQueue(WMT::CommandBuffer cmdbuf) {
+    barrier_index_++;
+    cmdbuf.encodeSignalEvent(barrier_event_, barrier_index_);
+    cmdbuf.encodeWaitForEvent(barrier_event_, barrier_index_);
+  };
+
   FrameStatistics&
   currentFrameStatistics();
 
@@ -792,8 +807,11 @@ private:
   std::vector<Rc<VisibilityResultQuery>> pending_queries_;
   unsigned active_visibility_query_count_ = 0;
   Flags<FeatureCompatibility> compatibility_flag_;
-
+  TimestampQueryState timestamp_state_;
   std::vector<Rc<VisibilityResultQuery> *> deferred_visibility_query_stack_;
+
+  WMT::Reference<WMT::Event> barrier_event_;
+  uint64_t barrier_index_ = 0;
 
   WMT::Device device_;
   CommandQueue& queue_;

--- a/src/dxmt/dxmt_context.hpp
+++ b/src/dxmt/dxmt_context.hpp
@@ -676,7 +676,7 @@ public:
   
   AllocatedTempBufferSlice allocateTempBuffer1(size_t size, size_t alignment);
 
-  std::unique_ptr<VisibilityResultReadback> flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId, uint64_t event_seq_id);
+  QueryReadbacks flushCommands(WMT::CommandBuffer cmdbuf, uint64_t seqId, uint64_t event_seq_id);
 
   uint64_t currentSeqId() {return seq_id_;}
 

--- a/src/dxmt/dxmt_occlusion_query.hpp
+++ b/src/dxmt/dxmt_occlusion_query.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace dxmt {
@@ -188,6 +189,10 @@ public:
   std::vector<Rc<VisibilityResultQuery>> queries;
   WMTBufferInfo visibility_result_heap_info;
   WMT::Reference<WMT::Buffer> visibility_result_heap;
+};
+
+struct QueryReadbacks {
+  std::unique_ptr<VisibilityResultReadback> visibility;
 };
 
 } // namespace dxmt

--- a/src/dxmt/dxmt_occlusion_query.hpp
+++ b/src/dxmt/dxmt_occlusion_query.hpp
@@ -191,8 +191,156 @@ public:
   WMT::Reference<WMT::Buffer> visibility_result_heap;
 };
 
+/**
+ * TODO: rename the whole file to dxmt_query.hpp
+ */
+
+class TimestampQuery {
+public:
+  void
+  incRef() {
+    refcount_.fetch_add(1u, std::memory_order_acquire);
+  }
+  void
+  decRef() {
+    if (refcount_.fetch_sub(1u, std::memory_order_release) == 1u)
+      delete this;
+  }
+
+  bool
+  getValue(uint64_t *value) {
+    if (cached_value_ == ~0ull)
+      return false;
+
+    *value = cached_value_;
+    return true;
+  }
+
+  void
+  issue(uint64_t sampled_data) {
+    cached_value_ = sampled_data;
+  }
+
+private:
+  uint64_t cached_value_ = ~0ull;
+  std::atomic<uint32_t> refcount_ = {0u};
+};
+
+using TimestampQueryList = std::vector<std::pair<Rc<TimestampQuery>, uint64_t>>;
+
+class TimestampReadbackSBuf {
+public:
+  TimestampReadbackSBuf(
+      WMT::Device device, WMT::CommandBuffer cmdbuf, uint64_t num_samples, TimestampQueryList &&queries
+  ) :
+      queries_(std::move(queries)),
+      num_samples_(num_samples) {
+    sample_buffer_ = device.newCounterSampleBuffer(num_samples, true);
+  }
+
+  ~TimestampReadbackSBuf() {
+    // TODO: small_vector opt
+    std::vector<uint64_t> results(num_samples_);
+    sample_buffer_.resolveCounterRange(0, num_samples_, results.data(), num_samples_ * sizeof(uint64_t));
+    for (const auto &[query, sample_index] : queries_) {
+      query->issue(results[sample_index]);
+    }
+  }
+
+  TimestampReadbackSBuf(const TimestampReadbackSBuf &) = delete;
+  TimestampReadbackSBuf(TimestampReadbackSBuf &&) = delete;
+
+  WMT::CounterSampleBuffer
+  sampleBuffer() {
+    return sample_buffer_;
+  };
+
+private:
+  TimestampQueryList queries_;
+  WMT::Reference<WMT::CounterSampleBuffer> sample_buffer_;
+  uint64_t num_samples_;
+};
+
+class TimestampReadbackCBuf {
+public:
+  TimestampReadbackCBuf(
+      WMT::Device device, WMT::CommandBuffer cmdbuf, uint64_t num_samples, TimestampQueryList &&queries
+  ) :
+      queries_(std::move(queries)),
+      num_samples_(num_samples),
+      cmdbuf_(cmdbuf) {}
+
+  ~TimestampReadbackCBuf() {
+    // TODO: small_vector opt
+    std::vector<uint64_t> results(num_samples_);
+    /**
+    There is no implicit relationship between `gpuEndTime` and order of commit, but we still want a later issued query
+    to return a timestamp greater or equal to previous ones, so check and use maximum.
+
+    `thread_local` makes sense because this destructor is only called on 1. finishing thread 2. (abnormal) device
+    destruction
+    */
+    thread_local uint64_t latest_ts_on_finish_thread = 0;
+    latest_ts_on_finish_thread = std::max(cmdbuf_.gpuEndTime(), latest_ts_on_finish_thread);
+    std::fill(results.begin(), results.end(), latest_ts_on_finish_thread);
+    for (const auto &[query, sample_index] : queries_) {
+      query->issue(results[sample_index]);
+    }
+  }
+
+  TimestampReadbackCBuf(const TimestampReadbackCBuf &) = delete;
+  TimestampReadbackCBuf(TimestampReadbackCBuf &&) = delete;
+
+  WMT::CounterSampleBuffer
+  sampleBuffer() {
+    return {};
+  };
+
+private:
+  TimestampQueryList queries_;
+  uint64_t num_samples_;
+  WMT::CommandBuffer cmdbuf_;
+};
+
+// compile-time: choose a timestamp impl: SBuf (sample buffer) or CBuf (command buffer `gpuEndTime`)
+using TimestampReadback = TimestampReadbackCBuf;
+
+class TimestampQueryState {
+public:
+  TimestampQueryState(WMT::Device device) : device_(device) {}
+
+  uint64_t
+  addQuery(TimestampQuery *query) {
+    queries_.push_back({query, num_samples_});
+    return num_samples_++;
+  }
+
+  void
+  coalaseQuery(TimestampQuery *query) {
+    assert(num_samples_);
+    queries_.push_back({query, num_samples_ - 1});
+  }
+
+  std::unique_ptr<TimestampReadback>
+  flush(WMT::CommandBuffer cmdbuf) {
+    if (num_samples_ == 0)
+      return {};
+
+    auto ret = std::make_unique<TimestampReadback>(device_, cmdbuf, num_samples_, std::move(queries_));
+    num_samples_ = 0;
+    queries_ = {};
+    return ret;
+  }
+
+private:
+  uint64_t num_samples_ = 0;
+  TimestampQueryList queries_;
+  WMT::Device device_;
+};
+
 struct QueryReadbacks {
   std::unique_ptr<VisibilityResultReadback> visibility;
+  std::unique_ptr<TimestampReadback> timestamp;
 };
 
 } // namespace dxmt

--- a/src/winemetal/Metal.hpp
+++ b/src/winemetal/Metal.hpp
@@ -614,6 +614,11 @@ public:
     return LogContainer{MTLCommandBuffer_logs(handle)};
   }
 
+  uint64_t
+  gpuEndTime() {
+    return MTLCommandBuffer_property(handle, WMTCommandBufferPropertyGPUEndTime);
+  }
+
   void
   encodeSignalEvent(Event event, uint64_t value) {
     return MTLCommandBuffer_encodeSignalEvent(handle, event.handle, value);

--- a/src/winemetal/Metal.hpp
+++ b/src/winemetal/Metal.hpp
@@ -204,6 +204,14 @@ class Fence : public Object {
 public:
 };
 
+class CounterSampleBuffer : public Object {
+public:
+  void
+  resolveCounterRange(uint32_t start, uint32_t len, void *data_out, uint64_t data_length) {
+    MTLCounterSampleBuffer_resolveCounterRange(handle, start, len, data_out, data_length);
+  }
+};
+
 class Resource : public Object {
 public:
 };
@@ -482,6 +490,19 @@ public:
     cmd.fence = fence.handle;
     MTLBlitCommandEncoder_encodeCommands(handle, (const wmtcmd_base *)&cmd);
   }
+
+  void
+  resolveCounters(CounterSampleBuffer sample_buffer, uint32_t start, uint32_t len, Buffer dst, uint64_t dst_offset) {
+    struct wmtcmd_blit_resolvecounters cmd;
+    cmd.type = WMTBlitCommandResolveCounters;
+    cmd.next.set(nullptr);
+    cmd.sample_buffer = sample_buffer.handle;
+    cmd.start = start;
+    cmd.len = len;
+    cmd.dst_buffer = dst.handle;
+    cmd.dst_offset = dst_offset;
+    MTLBlitCommandEncoder_encodeCommands(handle, (const wmtcmd_base *)&cmd);
+  }
 };
 
 class ComputeCommandEncoder : public CommandEncoder {
@@ -611,6 +632,11 @@ public:
   BlitCommandEncoder
   blitCommandEncoder() {
     return BlitCommandEncoder{MTLCommandBuffer_blitCommandEncoder(handle)};
+  }
+
+  BlitCommandEncoder
+  blitCommandEncoderWithSampleBuffers(WMTSampleBufferAttachmentInfo *attachments, uint64_t num_attachments) {
+    return BlitCommandEncoder{MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(handle, attachments, num_attachments)};
   }
 
   ComputeCommandEncoder
@@ -864,6 +890,11 @@ public:
   Reference<Texture>
   newSharedTexture(WMTTextureInfo &info) {
     return Reference<Texture>(MTLDevice_newSharedTexture(handle, &info));
+  }
+
+  Reference<CounterSampleBuffer>
+  newCounterSampleBuffer(uint32_t sample_count, bool shared = true) {
+    return Reference<CounterSampleBuffer>(MTLCounterSampleBuffer_newTimestampBuffer(handle, sample_count, shared));
   }
 };
 

--- a/src/winemetal/unix/winemetal_unix.c
+++ b/src/winemetal/unix/winemetal_unix.c
@@ -748,6 +748,14 @@ _MTLBlitCommandEncoder_encodeCommands(void *obj) {
       [encoder fillBuffer:(id<MTLBuffer>)body->buffer range:NSMakeRange(body->offset, body->length) value:body->value];
       break;
     }
+    case WMTBlitCommandResolveCounters: {
+      struct wmtcmd_blit_resolvecounters *body = (struct wmtcmd_blit_resolvecounters *)next;
+      [encoder resolveCounters:(id<MTLCounterSampleBuffer>)body->sample_buffer
+                       inRange:NSMakeRange(body->start, body->len)
+             destinationBuffer:(id<MTLBuffer>)body->dst_buffer
+             destinationOffset:body->dst_offset];
+      break;
+    }
     }
 
     next = next->next.ptr;
@@ -2660,6 +2668,63 @@ _MTLSharedEvent_waitUntilSignaledValue(void *obj) {
   return STATUS_SUCCESS;
 }
 
+static NTSTATUS
+_MTLCounterSampleBuffer_newTimestampBuffer(void *obj) {
+  struct unixcall_mtlcountersamplebuffer_newtimestampbuffer *params = obj;
+  id<MTLDevice> device = (id<MTLDevice>)params->device;
+
+  MTLCounterSampleBufferDescriptor *desc = [[MTLCounterSampleBufferDescriptor alloc] init];
+  NSArray<id<MTLCounterSet>> *counter_sets = [device counterSets];
+  id<MTLCounterSet> timestamp_counter_set = nil;
+  for (id<MTLCounterSet> counterSet in counter_sets) {
+    if ([counterSet.name isEqualToString:MTLCommonCounterSetTimestamp]) {
+      timestamp_counter_set = counterSet;
+      break;
+    }
+  }
+  desc.counterSet = timestamp_counter_set;
+  desc.sampleCount = params->sample_count;
+  desc.storageMode = params->shared ? MTLStorageModeShared : MTLStorageModePrivate;
+
+  NSError *error = nil;
+  params->ret = (obj_handle_t)[device newCounterSampleBufferWithDescriptor:desc error:&error];
+
+  [desc release];
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+_MTLCounterSampleBuffer_resolveCounterRange(void *obj) {
+  struct unixcall_mtlcountersamplebuffer_resolvecounterrange *params = obj;
+  id<MTLCounterSampleBuffer> sample_buffer = (id<MTLCounterSampleBuffer>)params->sample_buffer;
+
+  NSData *data = [sample_buffer resolveCounterRange:NSMakeRange(params->start, params->len)];
+  if (data && params->data_out.ptr) {
+    [data getBytes:params->data_out.ptr length:params->data_length];
+  }
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(void *obj) {
+  struct unixcall_mtlcommandbuffer_blitcommandencoderwithsamplebuffers *params = obj;
+  id<MTLCommandBuffer> cmdbuf = (id<MTLCommandBuffer>)params->cmdbuf;
+  struct WMTSampleBufferAttachmentInfo *attachments = params->attachments.ptr;
+
+  MTLBlitPassDescriptor *blit_desc = [[MTLBlitPassDescriptor alloc] init];
+  for (uint64_t i = 0; i < params->num_attachments; i++) {
+    MTLBlitPassSampleBufferAttachmentDescriptor *desc = blit_desc.sampleBufferAttachments[i];
+    desc.sampleBuffer = (id<MTLCounterSampleBuffer>)attachments[i].sample_buffer;
+    desc.startOfEncoderSampleIndex = attachments[i].start_of_encoder_sample_index;
+    desc.endOfEncoderSampleIndex = attachments[i].end_of_encoder_sample_index;
+  }
+
+  params->ret = (obj_handle_t)[cmdbuf blitCommandEncoderWithDescriptor:blit_desc];
+
+  [blit_desc release];
+  return STATUS_SUCCESS;
+}
+
 /*
  * Definition from cache.c
  */
@@ -2798,6 +2863,9 @@ const void *__wine_unix_call_funcs[] = {
     &_MTLDevice_newSharedEventWithMachPort,
     &_MTLDevice_registryID,
     &_MTLSharedEvent_waitUntilSignaledValue,
+    &_MTLCounterSampleBuffer_newTimestampBuffer,
+    &_MTLCounterSampleBuffer_resolveCounterRange,
+    &_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers,
 };
 
 #ifndef DXMT_NATIVE
@@ -2929,5 +2997,8 @@ const void *__wine_unix_call_wow64_funcs[] = {
     &_MTLDevice_newSharedEventWithMachPort,
     &_MTLDevice_registryID,
     &_MTLSharedEvent_waitUntilSignaledValue,
+    &_MTLCounterSampleBuffer_newTimestampBuffer,
+    &_MTLCounterSampleBuffer_resolveCounterRange,
+    &_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers,
 };
 #endif

--- a/src/winemetal/unix/winemetal_unix.c
+++ b/src/winemetal/unix/winemetal_unix.c
@@ -2725,6 +2725,31 @@ _MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(void *obj) {
   return STATUS_SUCCESS;
 }
 
+static NTSTATUS
+_MTLCommandBuffer_property(void *obj) {
+  struct unixcall_generic_obj_uint64_uint64_ret *params = obj;
+  id<MTLCommandBuffer> cmdbuf = (id<MTLCommandBuffer>)params->handle;
+  double ns = 1000000000;
+  switch (params->arg) {
+  case WMTCommandBufferPropertyKernelStartTime:
+    params->ret = (uint64_t)([cmdbuf kernelStartTime] * ns);
+    break;
+  case WMTCommandBufferPropertyKernelEndTime:
+    params->ret = (uint64_t)([cmdbuf kernelEndTime] * ns);
+    break;
+  case WMTCommandBufferPropertyGPUStartTime:
+    params->ret = (uint64_t)([cmdbuf GPUStartTime] * ns);
+    break;
+  case WMTCommandBufferPropertyGPUEndTime:
+    params->ret = (uint64_t)([cmdbuf GPUEndTime] * ns);
+    break;
+  default:
+    params->ret = 0;
+    break;
+  }
+  return STATUS_SUCCESS;
+}
+
 /*
  * Definition from cache.c
  */
@@ -2866,6 +2891,7 @@ const void *__wine_unix_call_funcs[] = {
     &_MTLCounterSampleBuffer_newTimestampBuffer,
     &_MTLCounterSampleBuffer_resolveCounterRange,
     &_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers,
+    &_MTLCommandBuffer_property,
 };
 
 #ifndef DXMT_NATIVE
@@ -3000,5 +3026,6 @@ const void *__wine_unix_call_wow64_funcs[] = {
     &_MTLCounterSampleBuffer_newTimestampBuffer,
     &_MTLCounterSampleBuffer_resolveCounterRange,
     &_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers,
+    &_MTLCommandBuffer_property,
 };
 #endif

--- a/src/winemetal/winemetal.h
+++ b/src/winemetal/winemetal.h
@@ -1878,4 +1878,13 @@ WINEMETAL_API obj_handle_t MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(
     uint64_t num_sample_buffer_attachments
 );
 
+enum WMTCommandBufferProperty : uint32_t {
+  WMTCommandBufferPropertyKernelStartTime,
+  WMTCommandBufferPropertyKernelEndTime,
+  WMTCommandBufferPropertyGPUStartTime,
+  WMTCommandBufferPropertyGPUEndTime,
+};
+
+WINEMETAL_API uint64_t MTLCommandBuffer_property(obj_handle_t cmdbuf, enum WMTCommandBufferProperty prop);
+
 #endif

--- a/src/winemetal/winemetal.h
+++ b/src/winemetal/winemetal.h
@@ -860,6 +860,7 @@ enum WMTBlitCommandType : uint16_t {
   WMTBlitCommandWaitForFence,
   WMTBlitCommandUpdateFence,
   WMTBlitCommandFillBuffer,
+  WMTBlitCommandResolveCounters,
 };
 
 struct wmtcmd_base {
@@ -952,6 +953,17 @@ struct wmtcmd_blit_fillbuffer {
   uint64_t offset;
   uint64_t length;
   uint8_t value;
+};
+
+struct wmtcmd_blit_resolvecounters {
+  enum WMTBlitCommandType type;
+  uint16_t reserved[3];
+  struct WMTMemoryPointer next;
+  obj_handle_t sample_buffer;
+  uint32_t start;
+  uint32_t len;
+  obj_handle_t dst_buffer;
+  uint64_t dst_offset;
 };
 
 WINEMETAL_API void MTLBlitCommandEncoder_encodeCommands(obj_handle_t encoder, const struct wmtcmd_base *cmd_head);
@@ -1847,5 +1859,23 @@ WINEMETAL_API obj_handle_t MTLDevice_newSharedEventWithMachPort(obj_handle_t dev
 WINEMETAL_API uint64_t MTLDevice_registryID(obj_handle_t device);
 
 WINEMETAL_API bool MTLSharedEvent_waitUntilSignaledValue(obj_handle_t event, uint64_t value, uint64_t timeout);
+
+WINEMETAL_API obj_handle_t
+MTLCounterSampleBuffer_newTimestampBuffer(obj_handle_t device, uint32_t sample_count, bool shared);
+
+WINEMETAL_API void MTLCounterSampleBuffer_resolveCounterRange(
+    obj_handle_t sample_buffer, uint32_t start, uint32_t len, void *data_out, uint64_t data_length
+);
+
+struct WMTSampleBufferAttachmentInfo {
+  obj_handle_t sample_buffer;
+  uint64_t start_of_encoder_sample_index;
+  uint64_t end_of_encoder_sample_index;
+};
+
+WINEMETAL_API obj_handle_t MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(
+    obj_handle_t cmdbuf, struct WMTSampleBufferAttachmentInfo *sample_buffer_attachments,
+    uint64_t num_sample_buffer_attachments
+);
 
 #endif

--- a/src/winemetal/winemetal_thunks.c
+++ b/src/winemetal/winemetal_thunks.c
@@ -1155,3 +1155,12 @@ MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(
   UNIX_CALL(129, &params);
   return params.ret;
 }
+
+WINEMETAL_API uint64_t
+MTLCommandBuffer_property(obj_handle_t cmdbuf, enum WMTCommandBufferProperty prop) {
+  struct unixcall_generic_obj_uint64_uint64_ret params;
+  params.handle = cmdbuf;
+  params.arg = prop;
+  UNIX_CALL(130, &params);
+  return params.ret;
+}

--- a/src/winemetal/winemetal_thunks.c
+++ b/src/winemetal/winemetal_thunks.c
@@ -1118,3 +1118,40 @@ MTLSharedEvent_waitUntilSignaledValue(obj_handle_t event, uint64_t value, uint64
   UNIX_CALL(126, &params);
   return params.ret_timeout;
 }
+
+WINEMETAL_API obj_handle_t
+MTLCounterSampleBuffer_newTimestampBuffer(obj_handle_t device, uint32_t sample_count, bool shared) {
+  struct unixcall_mtlcountersamplebuffer_newtimestampbuffer params;
+  params.device = device;
+  params.sample_count = sample_count;
+  params.shared = shared;
+  params.ret = 0;
+  UNIX_CALL(127, &params);
+  return params.ret;
+}
+
+WINEMETAL_API void
+MTLCounterSampleBuffer_resolveCounterRange(
+    obj_handle_t sample_buffer, uint32_t start, uint32_t len, void *data_out, uint64_t data_length
+) {
+  struct unixcall_mtlcountersamplebuffer_resolvecounterrange params;
+  params.sample_buffer = sample_buffer;
+  params.start = start;
+  params.len = len;
+  params.data_length = data_length;
+  WMT_MEMPTR_SET(params.data_out, data_out);
+  UNIX_CALL(128, &params);
+}
+
+WINEMETAL_API obj_handle_t
+MTLCommandBuffer_blitCommandEncoderWithSampleBuffers(
+    obj_handle_t cmdbuf, struct WMTSampleBufferAttachmentInfo *sample_buffer_attachments,
+    uint64_t num_sample_buffer_attachments) {
+  struct unixcall_mtlcommandbuffer_blitcommandencoderwithsamplebuffers params;
+  params.cmdbuf = cmdbuf;
+  WMT_MEMPTR_SET(params.attachments, sample_buffer_attachments);
+  params.num_attachments = num_sample_buffer_attachments;
+  params.ret = 0;
+  UNIX_CALL(129, &params);
+  return params.ret;
+}

--- a/src/winemetal/winemetal_thunks.h
+++ b/src/winemetal/winemetal_thunks.h
@@ -349,6 +349,28 @@ struct unixcall_mtlsharedevent_waituntilsignaledvalue {
   bool ret_timeout;
 };
 
+struct unixcall_mtlcountersamplebuffer_newtimestampbuffer {
+  obj_handle_t device;
+  uint32_t sample_count;
+  uint32_t shared;
+  obj_handle_t ret;
+};
+
+struct unixcall_mtlcountersamplebuffer_resolvecounterrange {
+  obj_handle_t sample_buffer;
+  uint32_t start;
+  uint32_t len;
+  struct WMTMemoryPointer data_out;
+  uint64_t data_length;
+};
+
+struct unixcall_mtlcommandbuffer_blitcommandencoderwithsamplebuffers {
+  obj_handle_t cmdbuf;
+  struct WMTMemoryPointer attachments;
+  uint64_t num_attachments;
+  obj_handle_t ret;
+};
+
 #pragma pack(pop)
 
 #endif


### PR DESCRIPTION
This PR add implementations for timestamp query.

Previously a timestamp query is effectively implemented as an event query, since games may use it as a GPU-CPU memory fence. And `GetData()` always gives 0. This works most of the time, but certain games do rely on meaningful timestamp value otherwise hang infinitely.

This PR contains two mechanisms to provide timestamp data: _CBuf_ (from command buffer's `gpuEndTime` property) and _SBuf_ (from Metal sample buffer, `MTLCounterSampleBuffer `)
- _CBuf_ is the default implementation at the moment because it is more reliable, but might be less precise and performant.
- _SBuf_ is what we eventually want, when work of fence-based synchronization is done. _Technically this is still incomplete at the moment, this PR makes it work, but not as fast as it is expected to be_.