### PR TITLE
feat: enable NoNaNs/NoInfs for pixel/compute shaders and add GVN/DSE passes

### DIFF
--- a/src/airconv/airconv_context.cpp
+++ b/src/airconv/airconv_context.cpp
@@ -23,6 +23,8 @@
 #include "llvm/Transforms/IPO/ForceFunctionAttrs.h"
 #include "llvm/Transforms/IPO/InferFunctionAttrs.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
+#include "llvm/Transforms/Scalar/GVN.h"
+#include "llvm/Transforms/Scalar/DeadStoreElimination.h"
 
 #include "airconv_context.hpp"
 
@@ -139,6 +141,8 @@ runOptimizationPasses(llvm::Module &M) {
     // optimizations.
     FunctionPassManager GlobalCleanupPM;
     GlobalCleanupPM.addPass(InstCombinePass());
+    GlobalCleanupPM.addPass(GVNPass());
+    GlobalCleanupPM.addPass(DSEPass());
 
     GlobalCleanupPM.addPass(SimplifyCFGPass(SimplifyCFGOptions().convertSwitchRangeToICmp(true)));
 

--- a/src/airconv/nt/dxbc_converter_base.cpp
+++ b/src/airconv/nt/dxbc_converter_base.cpp
@@ -2951,6 +2951,8 @@ Converter::UseFastMath(bool OptOut) {
     FMF.setAllowContract();
     FMF.setAllowReassoc();
     FMF.setAllowReciprocal();
+    FMF.setNoNaNs();
+    FMF.setNoInfs();
   }
 
   FMF.setApproxFunc();


### PR DESCRIPTION
## Summary

Enable more aggressive fast-math flags and additional LLVM optimization passes for the shader compilation pipeline:

- **NoNaNs + NoInfs** for pixel and compute shaders (not vertex — breaks vegetation invariance)
- **GVN** (Global Value Numbering) — eliminates redundant memory loads
- **DSE** (Dead Store Elimination) — removes dead stores

## Benchmark

Tested on **Apple M4** (10 GPU cores, 16 GB unified) with **World of Tanks** through CrossOver 26/Wine 11:

| Metric | Before | After |
|--------|--------|-------|
| FPS (HIGH, 1920×1200) | 50-60 | **~100** |
| GPU utilization avg | 74% | **40%** |
| GPU >90% time | 66% | **24%** |
| Memory bandwidth avg | 121 GB/s (HW limit!) | **14 GB/s** |

Profiled with Metal Frame Capture (Xcode GPU Debugger). The M4 was **bandwidth-bound** at 121/120 GB/s before these changes.

## Changes

- `src/airconv/nt/dxbc_converter_base.cpp`: Add `setNoNaNs()` and `setNoInfs()` to fast-math flags for pixel/compute shaders
- `src/airconv/airconv_context.cpp`: Add `GVNPass()` and `DSEPass()` to the LLVM optimization pipeline

## Notes

- NoNaNs/NoInfs intentionally **not** enabled for vertex shaders to preserve vegetation positioning
- Shader cache must be cleared after applying
- Other DX11 titles need community testing