### PR TITLE
fix(airconv): fix compile metal shader with toolchain from XCode 27 beta

### DIFF
--- a/src/airconv/shaders/air_tessellation.metal
+++ b/src/airconv/shaders/air_tessellation.metal
@@ -150,7 +150,7 @@ struct TessMeshWorkload {
 
 int
 get_next_index(threadgroup int *out_count) {
-  return __metal_atomic_fetch_add_explicit(out_count, 1, int(memory_order_relaxed), __METAL_MEMORY_SCOPE_THREADGROUP__);
+  return atomic_fetch_add_explicit(reinterpret_cast<threadgroup atomic_int *>(out_count), 1, memory_order_relaxed);
 }
 
 template <partitioning partition>


### PR DESCRIPTION
Fixed `air_tessellation.metal` compilation with the Metal toolchain from Xcode 27 beta.
Private built-in `__metal_atomic_fetch_add_explicit` changed arguments with the newer toolchain.
New argument was added as a memory flag.

Instead use private Metal API, use public `atomic_fetch_add_explicit`.

I tested with games `The Medium` and `Mass Effect: Andromeda`.