### PR TITLE
feat(d3d11): implement SwapDeviceContextState

### DIFF
--- a/src/d3d11/d3d11_context_impl.cpp
+++ b/src/d3d11/d3d11_context_impl.cpp
@@ -1884,7 +1884,26 @@ public:
   void
   STDMETHODCALLTYPE
   SwapDeviceContextState(ID3DDeviceContextState *pState, ID3DDeviceContextState **ppPreviousState) override {
-    UNIMPLEMENTED("SwapDeviceContextState");
+    // Callers (e.g. Direct2D interop) swap their own pipeline state in and the
+    // application's state out around a render pass. Save the current pipeline
+    // state into the returned previous-state token, then activate the incoming
+    // token's saved state.
+    if (!pState) {
+      if (ppPreviousState)
+        *ppPreviousState = nullptr;
+      return;
+    }
+    std::lock_guard<mutex_t> lock(mutex);
+    auto incoming = static_cast<MTLD3D11DeviceContextState *>(pState);
+    if (ppPreviousState) {
+      auto previous = new MTLD3D11DeviceContextState(device);
+      previous->saved_state = std::move(state_);
+      *ppPreviousState = ref(previous);
+    }
+    state_ = std::move(incoming->saved_state);
+    incoming->saved_state = {};
+    ResetEncodingContextState();
+    InvalidateRenderPipeline();
   }
 
   void

--- a/src/d3d11/d3d11_context_state.hpp
+++ b/src/d3d11/d3d11_context_state.hpp
@@ -211,6 +211,11 @@ public:
 
     return E_NOINTERFACE;
   }
+
+  // Saved pipeline state for SwapDeviceContextState. A newly created token
+  // carries default (empty) state, giving the caller a clean context to render
+  // into; swapping back restores the previously saved state.
+  D3D11ContextState saved_state = {};
 };
 
 } // namespace dxmt


### PR DESCRIPTION
## Summary

`SwapDeviceContextState` was `UNIMPLEMENTED`. Callers such as Direct2D interop use it to swap their own pipeline state in and the application's state out around each render pass, so any such render loop aborts at the first call (e.g. Wine's Direct2D at the first `Clear`).

DXMT already has the pieces needed: a single `D3D11ContextState` struct, the context's `state_`, `ResetEncodingContextState()` and `InvalidateRenderPipeline()`. This change:

- adds a `D3D11ContextState saved_state` slot to `MTLD3D11DeviceContextState`
- saves the current `state_` into the returned previous-state token
- activates the incoming token's saved state
- resets encoding state and invalidates the render pipeline so the Metal side follows the new state

## Testing

Verified on macOS with a CrossOver/Wine runtime on an Apple M-series GPU. Together with the `IDXGISurface` change (#171), a Wine Direct2D render loop (`BeginDraw → Clear → draw → EndDraw`) runs ~150 frames with `EndDraw` returning `S_OK` and no errors in the log.

## Notes

Builds on the existing context-state machinery rather than introducing new state tracking.