### PR TITLE
dxmt(fix) show DXMT version in HUD on macOS27

### DIFF
--- a/src/dxmt/dxmt_hud_state.cpp
+++ b/src/dxmt/dxmt_hud_state.cpp
@@ -9,8 +9,19 @@ HUDState::initialize(const std::string &heading) {
   using namespace WMT;
   auto pool = MakeAutoreleasePool();
   auto str_dxmt_version = MakeString("com.github.3shain.dxmt-version", WMTUTF8StringEncoding);
-  hud_.addLabel(str_dxmt_version, String::string("com.apple.hud-graph.default", WMTUTF8StringEncoding));
-  hud_.updateLabel(str_dxmt_version, String::string(heading.c_str(), WMTUTF8StringEncoding));
+  uint64_t macos_major_version = 0, macos_minor_version = 0;
+  WMTGetOSVersion(&macos_major_version, &macos_minor_version, nullptr);
+  if (macos_major_version >= 27) {
+    hud_.addMetric(
+        str_dxmt_version,
+        String::string(heading.c_str(), WMTUTF8StringEncoding),
+        String::string("", WMTUTF8StringEncoding),
+        0xFFFFFFFF, 0x00000000, 0x800, 0);
+    hud_.updateIntegerMetric(str_dxmt_version, 1);
+  } else {
+    hud_.addLabel(str_dxmt_version, String::string("com.apple.hud-graph.default", WMTUTF8StringEncoding));
+    hud_.updateLabel(str_dxmt_version, String::string(heading.c_str(), WMTUTF8StringEncoding));
+  }
   line_labels_.push_back(std::move(str_dxmt_version));
 }
 

--- a/src/winemetal/Metal.hpp
+++ b/src/winemetal/Metal.hpp
@@ -949,6 +949,16 @@ public:
   }
 
   void
+  addMetric(String metric, String name, String unit, uint32_t nameColor, uint32_t valueColor, uint32_t visualType, uint32_t options) {
+    DeveloperHUDProperties_addMetric(handle, metric, name, unit, nameColor, valueColor, visualType, options);
+  }
+
+  void
+  updateIntegerMetric(String metric, int64_t value) {
+    DeveloperHUDProperties_updateMetric(handle, metric, value);
+  }
+
+  void
   remove(String label) {
     DeveloperHUDProperties_remove(handle, label);
   }

--- a/src/winemetal/unix/winemetal_unix.c
+++ b/src/winemetal/unix/winemetal_unix.c
@@ -1517,6 +1517,25 @@ _DeveloperHUDProperties_updateLabel(void *obj) {
 }
 
 static NTSTATUS
+_DeveloperHUDProperties_addMetric(void *obj) {
+  struct unixcall_generic_obj_obj_obj_obj_uint_uint_uint_uint_noret *params = obj;
+  ((void (*)(id, SEL, id, id, id, NSUInteger, NSUInteger, NSUInteger, NSUInteger)
+  )objc_msgSend)(
+      (id)params->handle, @selector(addMetric:name:unit:nameColor:valueColor:visualType:options:),
+      (id)params->arg0, (id)params->arg1, (id)params->arg2, (NSUInteger)params->arg3,
+      (NSUInteger)params->arg4, (NSUInteger)params->arg5, (NSUInteger)params->arg6);
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+_DeveloperHUDProperties_updateIntegerMetric(void *obj) {
+  struct unixcall_generic_obj_obj_int64_noret *params = obj;
+  ((void (*)(id, SEL, id, NSInteger)
+  )objc_msgSend)((id)params->handle, @selector(updateIntegerMetric:value:), (id)params->arg0, (NSInteger)params->arg1);
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS
 _DeveloperHUDProperties_remove(void *obj) {
   struct unixcall_generic_obj_obj_noret *params = obj;
   ((void (*)(id, SEL, id))objc_msgSend)((id)params->handle, @selector(remove:), (id)params->arg);
@@ -2999,6 +3018,8 @@ const void *__wine_unix_call_funcs[] = {
     &_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers,
     &_MTLCommandBuffer_property,
     &_MTLDevice_newTileRenderPipelineState,
+    &_DeveloperHUDProperties_addMetric,
+    &_DeveloperHUDProperties_updateIntegerMetric,
 };
 
 #ifndef DXMT_NATIVE
@@ -3135,5 +3156,7 @@ const void *__wine_unix_call_wow64_funcs[] = {
     &_MTLCommandBuffer_blitCommandEncoderWithSampleBuffers,
     &_MTLCommandBuffer_property,
     &_MTLDevice_newTileRenderPipelineState,
+    &_DeveloperHUDProperties_addMetric,
+    &_DeveloperHUDProperties_updateIntegerMetric,
 };
 #endif

--- a/src/winemetal/winemetal.h
+++ b/src/winemetal/winemetal.h
@@ -1654,6 +1654,13 @@ WINEMETAL_API bool DeveloperHUDProperties_addLabel(obj_handle_t obj, obj_handle_
 
 WINEMETAL_API void DeveloperHUDProperties_updateLabel(obj_handle_t obj, obj_handle_t label, obj_handle_t value);
 
+WINEMETAL_API void
+DeveloperHUDProperties_addMetric(
+    obj_handle_t obj, obj_handle_t metric, obj_handle_t name, obj_handle_t unit,
+    uint32_t nameColor, uint32_t valueColor, uint32_t visualType, uint32_t options);
+
+WINEMETAL_API void DeveloperHUDProperties_updateMetric(obj_handle_t obj, obj_handle_t metric, int64_t value);
+
 WINEMETAL_API void DeveloperHUDProperties_remove(obj_handle_t obj, obj_handle_t label);
 
 WINEMETAL_API obj_handle_t MetalDrawable_texture(obj_handle_t drawable);

--- a/src/winemetal/winemetal_thunks.c
+++ b/src/winemetal/winemetal_thunks.c
@@ -652,6 +652,31 @@ DeveloperHUDProperties_updateLabel(obj_handle_t obj, obj_handle_t label, obj_han
 }
 
 WINEMETAL_API void
+DeveloperHUDProperties_addMetric(
+    obj_handle_t obj, obj_handle_t metric, obj_handle_t name, obj_handle_t unit,
+    uint32_t nameColor, uint32_t valueColor, uint32_t visualType, uint32_t options) {
+  struct unixcall_generic_obj_obj_obj_obj_uint_uint_uint_uint_noret params;
+  params.handle = obj;
+  params.arg0 = metric;
+  params.arg1 = name;
+  params.arg2 = unit;
+  params.arg3 = nameColor;
+  params.arg4 = valueColor;
+  params.arg5 = visualType;
+  params.arg6 = options;
+  UNIX_CALL(132, &params);
+}
+
+WINEMETAL_API void
+DeveloperHUDProperties_updateMetric(obj_handle_t obj, obj_handle_t metric, int64_t value) {
+  struct unixcall_generic_obj_obj_int64_noret params;
+  params.handle = obj;
+  params.arg0 = metric;
+  params.arg1 = value;
+  UNIX_CALL(133, &params);
+}
+
+WINEMETAL_API void
 DeveloperHUDProperties_remove(obj_handle_t obj, obj_handle_t label) {
   struct unixcall_generic_obj_obj_noret params;
   params.handle = obj;

--- a/src/winemetal/winemetal_thunks.h
+++ b/src/winemetal/winemetal_thunks.h
@@ -165,6 +165,23 @@ struct unixcall_generic_obj_obj_obj_noret {
   obj_handle_t arg1;
 };
 
+struct unixcall_generic_obj_obj_obj_obj_uint_uint_uint_uint_noret {
+  obj_handle_t handle;
+  obj_handle_t arg0;
+  obj_handle_t arg1;
+  obj_handle_t arg2;
+  uint32_t arg3;
+  uint32_t arg4;
+  uint32_t arg5;
+  uint32_t arg6;
+};
+
+struct unixcall_generic_obj_obj_int64_noret {
+  obj_handle_t handle;
+  obj_handle_t arg0;
+  int64_t arg1;
+};
+
 struct unixcall_generic_obj_obj_obj_uint64_ret {
   obj_handle_t handle;
   obj_handle_t arg0;


### PR DESCRIPTION
This is semi workaround, it requires turning on "Show metrics with 0 Value" in the HUD configuration panel.
