### PR TITLE
util: include <iomanip> in com_guid.cpp

### DIFF
--- a/src/util/com/com_guid.cpp
+++ b/src/util/com/com_guid.cpp
@@ -8,6 +8,7 @@
  * See <https://github.com/doitsujin/dxvk/blob/master/LICENSE>
  */
 
+#include <iomanip>
 #include <mutex>
 #include <unordered_set>
 


### PR DESCRIPTION
`com_guid.cpp` uses `std::setw`/`std::setfill` but only pulled them in transitively; mingw-w64 GCC 15 no longer does, breaking the build. Include `<iomanip>` explicitly.