### PR TITLE
d3d11: only dirty stages that bind a CB on WRITE_DISCARD map

### DIFF
--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -162,14 +162,10 @@ public:
           state_.InputAssembler.VertexBuffers.set_dirty();
         }
         if (bind_flag & D3D11_BIND_CONSTANT_BUFFER) {
-          for (auto &stage : state_.ShaderStages) {
-            stage.ConstantBuffers.set_dirty();
-          }
+          dirtyConstantBufferStages(state_.ShaderStages, GetResourceCommon(pResource));
         }
         if (bind_flag & D3D11_BIND_SHADER_RESOURCE) {
-          for (auto &stage : state_.ShaderStages) {
-            stage.SRVs.set_dirty();
-          }
+          dirtyShaderResourceStages(state_.ShaderStages, GetResourceCommon(pResource));
         }
 
         pMappedResource->pData = MapDynamicBuffer(dynamic);
@@ -201,9 +197,7 @@ public:
       case D3D11_MAP_READ_WRITE:
         return E_INVALIDARG;
       case D3D11_MAP_WRITE_DISCARD: {
-        for (auto &stage : state_.ShaderStages) {
-            stage.SRVs.set_dirty();
-        }
+        dirtyShaderResourceStages(state_.ShaderStages, GetResourceCommon(pResource));
         Rc<TextureAllocation> new_allocation = dynamic->allocate(ctx_state.cmd_queue.CoherentSeqId());
         uint32_t id = ctx_state.current_cmdlist->used_dynamic_lineartextures.size();
         // track the current allocation in case of a following NO_OVERWRITE map
@@ -251,9 +245,7 @@ public:
       case D3D11_MAP_WRITE_NO_OVERWRITE:
         return E_INVALIDARG;
       case D3D11_MAP_WRITE_DISCARD: {
-        for (auto &stage : state_.ShaderStages) {
-            stage.SRVs.set_dirty();
-        }
+        dirtyShaderResourceStages(state_.ShaderStages, GetResourceCommon(pResource));
         pMappedResource->pData = MapDynamicBuffer(dynamic);
         pMappedResource->RowPitch = row_pitch;
         pMappedResource->DepthPitch = depth_pitch;

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -156,14 +156,10 @@ public:
           state_.InputAssembler.VertexBuffers.set_dirty();
         }
         if (bind_flag & D3D11_BIND_CONSTANT_BUFFER) {
-          for (auto &stage : state_.ShaderStages) {
-            stage.ConstantBuffers.set_dirty();
-          }
+          dirtyConstantBufferStages(state_.ShaderStages, GetResourceCommon(pResource));
         }
         if (bind_flag & D3D11_BIND_SHADER_RESOURCE) {
-          for (auto &stage : state_.ShaderStages) {
-            stage.SRVs.set_dirty();
-          }
+          dirtyShaderResourceStages(state_.ShaderStages, GetResourceCommon(pResource));
         }
 
         pMappedResource->pData = MapDynamicBuffer(dynamic, current_seq_id, coherent_seq_id);
@@ -188,9 +184,7 @@ public:
       case D3D11_MAP_WRITE_NO_OVERWRITE:
         return E_INVALIDARG;
       case D3D11_MAP_WRITE_DISCARD: {
-        for (auto &stage : state_.ShaderStages) {
-          stage.SRVs.set_dirty();
-        }
+        dirtyShaderResourceStages(state_.ShaderStages, GetResourceCommon(pResource));
 
         pMappedResource->pData = MapDynamicBuffer(dynamic, current_seq_id, coherent_seq_id);
         pMappedResource->RowPitch = row_pitch;
@@ -207,9 +201,7 @@ public:
       case D3D11_MAP_READ_WRITE:
         return E_INVALIDARG;
       case D3D11_MAP_WRITE_DISCARD: {
-        for (auto &stage : state_.ShaderStages) {
-          stage.SRVs.set_dirty();
-        }
+        dirtyShaderResourceStages(state_.ShaderStages, GetResourceCommon(pResource));
 
         dynamic->updateImmediateName(current_seq_id, dynamic->allocate(coherent_seq_id), false);
         EmitST([allocation = dynamic->immediateName(),

--- a/src/d3d11/d3d11_context_state.hpp
+++ b/src/d3d11/d3d11_context_state.hpp
@@ -213,4 +213,30 @@ public:
   }
 };
 
+/** On discard-map the backing rotates, so dirty only the stages that bind the
+ *  mapped resource — the rest would re-encode their tables for nothing. */
+inline void
+dirtyConstantBufferStages(D3D11StagesState<D3D11ShaderStageState> &stages, D3D11ResourceCommon *resource) {
+  for (auto &stage : stages) {
+    for (const auto &[slot, entry] : stage.ConstantBuffers) {
+      if (entry.Buffer.ptr() == resource) {
+        stage.ConstantBuffers.set_dirty();
+        break;
+      }
+    }
+  }
+}
+
+inline void
+dirtyShaderResourceStages(D3D11StagesState<D3D11ShaderStageState> &stages, D3D11ResourceCommon *resource) {
+  for (auto &stage : stages) {
+    for (const auto &[slot, entry] : stage.SRVs) {
+      if (entry.SRV->resource_.ptr() == resource) {
+        stage.SRVs.set_dirty();
+        break;
+      }
+    }
+  }
+}
+
 } // namespace dxmt


### PR DESCRIPTION
WRITE_DISCARD of a dynamic buffer/texture used to dirty every shader stage's CB/SRV set, forcing a redundant argument-table re-encode next draw on stages that never bound it. Now only stages that actually bind the resource are dirtied, on both immediate and deferred contexts.