### PR TITLE
Ignore ID3D11InfoQueue and IWineDXGIAdapter interface requests

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1198,7 +1198,7 @@ public:
       return S_OK;
     }
 
-    if (riid == __uuidof(ID3D11Debug))
+    if (riid == __uuidof(ID3D11Debug) || riid == __uuidof(ID3D11InfoQueue) || riid == __uuidof(IMTLD3D11ContextExt))
       return E_NOINTERFACE;
 
     if (riid == kRenderdocUUID || riid == kPixUUID || riid == kGpaUUID)

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -11,6 +11,11 @@
 
 namespace dxmt {
 
+const GUID kWineDXGIAdapterUUID = {0x17399d75,
+                                   0x964e,
+                                   0x4c03,
+                                   {0x99, 0xf8, 0x9d, 0x4f, 0xd1, 0x96, 0xdd, 0x62}};
+
 Com<IDXGIOutput> CreateOutput(IMTLDXGIAdapter *pAadapter, HMONITOR monitor, DxgiOptions &options);
 
 LUID GetAdapterLuid(WMT::Device device) {
@@ -53,6 +58,9 @@ public:
       *ppvObject = ref(this);
       return S_OK;
     }
+
+    if (riid == kWineDXGIAdapterUUID)
+      return E_NOINTERFACE;
 
     if (logQueryInterfaceError(__uuidof(IDXGIAdapter), riid)) {
       WARN("DXGIAdapter: Unknown interface query ", str::format(riid));


### PR DESCRIPTION
Ignore `ID3D11InfoQueue` for `Dishonored` games.
Ignore `IWineDXGIAdapter` for `Tomb Raider 2/3`, `Control`, `Crysis Remastered`
Ignore `IMTLD3D11ContextExt` from `D3D11Device` query - triggered with UE4 games
