### PR TITLE
fix(d3d12) fix crash in D3D12CreateDevice() on non null adapter as argument

### DIFF
--- a/src/d3d12/d3d12.cpp
+++ b/src/d3d12/d3d12.cpp
@@ -50,6 +50,8 @@ D3D12CreateDevice(IUnknown *pAdapter, D3D_FEATURE_LEVEL MinimumFeatureLevel, REF
       ERR("D3D12CreateDevice: No default adapter available");
       return hr;
     }
+  } else {
+    dxgi_adapter = com_cast<IDXGIAdapter>(pAdapter);
   }
 
   if (FAILED(hr = dxgi_adapter->QueryInterface(IID_PPV_ARGS(&dxgi_adapter_mtl)))) {


### PR DESCRIPTION
D3D12HelloTriangle example create DXGI adapter before calling `D3D12CreateDevice()`