### PR TITLE
d3d11: refcount per-HWND Metal view to fix ANGLE white screen (#183)

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -97,13 +97,16 @@ GetMonitorFormatBpp(DXGI_FORMAT Format) {
  * The macdrv metal view is a PER-WINDOW singleton: WMT::CreateMetalViewFromHWND
  * (backed by winemac.drv's macdrv_view_create_metal_view) returns the
  * already-existing WineMetalView for a window on repeated calls, and
- * WMT::ReleaseMetalView removes that view from the window outright. If an
- * application creates a second swapchain on the same HWND while the first
- * still exists (e.g. ANGLE recreates its swapchain on resize), both swapchains
- * share ONE view — and destroying the old swapchain detaches the view the new
- * swapchain is presenting into, leaving a permanently blank (GDI-background)
- * window while every present still "succeeds". Refcount the view per HWND so
- * it is only released when the last swapchain using it goes away.
+ * WMT::ReleaseMetalView removes that view from the window outright. If a
+ * second swapchain is created on the same HWND while the first still exists
+ * (e.g. an EGL client recreating its window surface: eglDestroySurface on a
+ * surface that is still current only schedules destruction, so ANGLE creates
+ * the new surface's swapchain before the old surface — and its swapchain —
+ * is released on the next eglMakeCurrent), both swapchains share ONE view —
+ * and destroying the old swapchain detaches the view the new swapchain is
+ * presenting into, leaving a permanently blank (GDI-background) window while
+ * every present still "succeeds". Refcount the view per HWND so it is only
+ * released when the last swapchain using it goes away.
  *
  * Locking: WMT:: calls cross into the unix side (AppKit) and must never run
  * under g_metal_view_mutex. The view is created before the lock is taken (a

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -94,19 +94,19 @@ GetMonitorFormatBpp(DXGI_FORMAT Format) {
 }
 
 /**
- * The macdrv metal view is a PER-WINDOW singleton: WMT::CreateMetalViewFromHWND
+ * The macdrv metal view is a per-window singleton: WMT::CreateMetalViewFromHWND
  * (backed by winemac.drv's macdrv_view_create_metal_view) returns the
  * already-existing WineMetalView for a window on repeated calls, and
- * WMT::ReleaseMetalView removes that view from the window outright. If a
- * second swapchain is created on the same HWND while the first still exists
- * (e.g. an EGL client recreating its window surface: eglDestroySurface on a
- * surface that is still current only schedules destruction, so ANGLE creates
- * the new surface's swapchain before the old surface — and its swapchain —
- * is released on the next eglMakeCurrent), both swapchains share ONE view —
- * and destroying the old swapchain detaches the view the new swapchain is
- * presenting into, leaving a permanently blank (GDI-background) window while
- * every present still "succeeds". Refcount the view per HWND so it is only
- * released when the last swapchain using it goes away.
+ * WMT::ReleaseMetalView removes that view from the window outright. A second
+ * swapchain can be created on the same HWND while the first still exists.
+ * For example, an EGL client that recreates its window surface: destroying a
+ * surface that is still current only schedules the destruction, so ANGLE
+ * creates the new surface's swapchain before the old surface (and its
+ * swapchain) is released on the next eglMakeCurrent. Both swapchains then
+ * share one view, and destroying the old swapchain detaches the view the new
+ * swapchain is presenting into, leaving a permanently blank (GDI-background)
+ * window while every present still "succeeds". Refcount the view per HWND so
+ * it is only released when the last swapchain using it goes away.
  *
  * Locking: WMT:: calls cross into the unix side (AppKit) and must never run
  * under g_metal_view_mutex. The view is created before the lock is taken (a
@@ -172,7 +172,7 @@ ReleaseMetalViewForHWND(HWND hwnd, WMT::Object view) {
     std::lock_guard<dxmt::mutex> lock(g_metal_view_mutex);
     auto it = g_metal_views.find((intptr_t)hwnd);
     /* No entry, or the entry was superseded because the HWND was recycled: the
-     * view this swapchain held has already been released — do nothing. */
+     * view this swapchain held has already been released; do nothing. */
     if (it == g_metal_views.end() || it->second.view != view)
       return;
     if (--it->second.refcount > 0)

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -11,6 +11,7 @@
 #include "dxmt_statistics.hpp"
 #include "dxmt_presenter.hpp"
 #include "log/log.hpp"
+#include "thread.hpp"
 #include "d3d11_resource.hpp"
 #include "d3d11_device.hpp"
 #include "util_cpu_fence.hpp"
@@ -25,6 +26,7 @@
 #include <atomic>
 #include <cfloat>
 #include <format>
+#include <unordered_map>
 
 /**
 Ref: https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_3/nf-dxgi1_3-idxgiswapchain2-setmaximumframelatency
@@ -91,6 +93,93 @@ GetMonitorFormatBpp(DXGI_FORMAT Format) {
   }
 }
 
+/**
+ * The macdrv metal view is a PER-WINDOW singleton: WMT::CreateMetalViewFromHWND
+ * (backed by winemac.drv's macdrv_view_create_metal_view) returns the
+ * already-existing WineMetalView for a window on repeated calls, and
+ * WMT::ReleaseMetalView removes that view from the window outright. If an
+ * application creates a second swapchain on the same HWND while the first
+ * still exists (e.g. ANGLE recreates its swapchain on resize), both swapchains
+ * share ONE view — and destroying the old swapchain detaches the view the new
+ * swapchain is presenting into, leaving a permanently blank (GDI-background)
+ * window while every present still "succeeds". Refcount the view per HWND so
+ * it is only released when the last swapchain using it goes away.
+ *
+ * Locking: WMT:: calls cross into the unix side (AppKit) and must never run
+ * under g_metal_view_mutex. The view is created before the lock is taken (a
+ * racing create for the same window just returns the same singleton), and
+ * releases extract the stored handle under the lock but invoke
+ * WMT::ReleaseMetalView only after dropping it.
+ */
+namespace {
+struct SharedMetalView {
+  WMT::Object view;
+  WMT::MetalLayer layer;
+  uint32_t refcount;
+};
+} // namespace
+
+static dxmt::mutex g_metal_view_mutex;
+static std::unordered_map<intptr_t, SharedMetalView> g_metal_views;
+
+static WMT::Object
+AcquireMetalViewForHWND(HWND hwnd, WMT::Device device, WMT::MetalLayer &layer) {
+  WMT::MetalLayer fresh_layer;
+  WMT::Object fresh_view = WMT::CreateMetalViewFromHWND((intptr_t)hwnd, device, fresh_layer);
+  if (!fresh_view)
+    return fresh_view;
+
+  WMT::Object stale_view = {};
+  {
+    std::lock_guard<dxmt::mutex> lock(g_metal_view_mutex);
+    auto it = g_metal_views.find((intptr_t)hwnd);
+    if (it == g_metal_views.end()) {
+      g_metal_views.emplace((intptr_t)hwnd, SharedMetalView{fresh_view, fresh_layer, 1u});
+    } else if (it->second.view == fresh_view) {
+      /* Another live swapchain already uses this window's view: share it. */
+      ++it->second.refcount;
+      layer = it->second.layer;
+      return it->second.view;
+    } else {
+      /* The HWND value was recycled for a new window: the stored view belongs
+       * to a window that no longer exists. Hand out the fresh view and release
+       * the stale one below, outside the lock. Swapchains still holding the
+       * stale view become no-ops in ReleaseMetalViewForHWND via its identity
+       * check. */
+      stale_view = it->second.view;
+      it->second = SharedMetalView{fresh_view, fresh_layer, 1u};
+    }
+  }
+  if (stale_view)
+    WMT::ReleaseMetalView(stale_view);
+  layer = fresh_layer;
+  return fresh_view;
+}
+
+/**
+ * \param view The view handle this swapchain obtained from
+ * AcquireMetalViewForHWND. Used purely as an identity token to detect that the
+ * map entry was superseded (HWND recycled); the stored handle is what gets
+ * released.
+ */
+static void
+ReleaseMetalViewForHWND(HWND hwnd, WMT::Object view) {
+  WMT::Object last_view = {};
+  {
+    std::lock_guard<dxmt::mutex> lock(g_metal_view_mutex);
+    auto it = g_metal_views.find((intptr_t)hwnd);
+    /* No entry, or the entry was superseded because the HWND was recycled: the
+     * view this swapchain held has already been released — do nothing. */
+    if (it == g_metal_views.end() || it->second.view != view)
+      return;
+    if (--it->second.refcount > 0)
+      return;
+    last_view = it->second.view;
+    g_metal_views.erase(it);
+  }
+  WMT::ReleaseMetalView(last_view);
+}
+
 class ModeSetGuard {
   std::atomic_flag in_progress_;
 public:
@@ -131,7 +220,7 @@ public:
       monitor_(wsi::getWindowMonitor(hWnd)),
       hud(WMT::DeveloperHUDProperties::instance()) {
 
-    native_view_ = WMT::CreateMetalViewFromHWND((intptr_t)hWnd, pDevice->GetMTLDevice(), layer_weak_);
+    native_view_ = AcquireMetalViewForHWND(hWnd, pDevice->GetMTLDevice(), layer_weak_);
 
     if (!native_view_) {
       ERR("Failed to create metal view, it seems like your Wine has no exported symbols needed by DXMT.");
@@ -206,7 +295,7 @@ public:
 
   ~MTLD3D11SwapChain() {
     device_context_->WaitUntilGPUIdle();
-    WMT::ReleaseMetalView(native_view_);
+    ReleaseMetalViewForHWND(hWnd, native_view_);
     native_view_ = {};
     CloseHandle(present_semaphore_);
   };


### PR DESCRIPTION
Fixes #183.

**Problem**

Games that render through ANGLE (GLES over D3D11; they ship libEGL.dll + libGLESv2.dll) present a pure white window under DXMT. Audio and input work and there are no errors from the game, ANGLE, or DXMT. The same binaries render correctly under D3DMetal, so the game and ANGLE are fine; the gap is DXMT-side.

**Root cause**

winemac.drv's `newMetalViewWithDevice:` returns a per-window singleton (`if (_metalView) return _metalView;`, no extra retain), and `macdrv_view_release_metal_view` does removeFromSuperview + release (dealloc). The D3D11 swapchain creates/releases that view per swapchain with no refcount.

The repro game (My Singing Monsters, appid 1419170, free, 32-bit) destroys and recreates its EGL window surface during startup. EGL requires deferred destruction there: destroying a surface that is still current only schedules it, and the surface is really destroyed once it stops being current. ANGLE implements exactly that, so at the D3D level the order is always: swapchain #2 gets created on the same HWND first, then the old surface dies on the next eglMakeCurrent and swapchain #1's destructor runs. Both chains hold the same singleton view, so the old destructor detaches the view the live swapchain is presenting into. Every later present succeeds into an orphaned view and the window shows its blank background. Apps that create one swapchain per window never hit this.

Trace from an instrumented build (logging only, stock view lifetime):

```
CreateSwapChain hwnd=0x110194 size=1024x768  bufferCount=1 swapEffect=1
SwapChain ctor  hwnd=0x110194 view=140676770627888
CreateSwapChain hwnd=0x110194 size=1920x1080 bufferCount=1 swapEffect=1
SwapChain ctor  hwnd=0x110194 view=140676770627888   <- same view (winemac singleton)
SwapChain dtor  hwnd=0x110194 view=140676770627888 -> ReleaseMetalView (detach)
Present1 #120 ... #1080   <- presents keep succeeding into the detached view
```

Window capture during this run is 100% white. A diagnostic build that cleared every drawable to magenta still produced a pure white on-screen window, which is how the detached-layer theory was confirmed in the first place. ANGLE source links backing the surface-recreation mechanism are in the comments below.

**Fix**

A process-global refcounted HWND -> {view, layer, refcount} map in d3d11_swapchain.cpp. The view is created once per window and released only when the last swapchain on that HWND is destroyed. The tricky parts:

- No WMT:: calls under the lock. CreateMetalViewFromHWND runs before the lock is taken (it returns the singleton, so a race just yields the same handle); the view to release is extracted under the lock and ReleaseMetalView is called after the lock is dropped.
- Recycled HWNDs. Windows reuses handle values, so acquire compares the current singleton handle against the stored entry. On mismatch it replaces the entry and releases the stale view; otherwise a new window would inherit a detached view, which is the original bug again, silently.
- Release only the canonical stored handle, exactly once. Never the caller's parameter, and never on a map miss, so no double-release or use-after-free.

With the fix, the same startup sequence logs CREATE refcount=1, REUSE refcount=2, KEPT ALIVE refcount=1, and the game renders (window capture 0.2% white, ~4,700 distinct colors).

**Why d3d11, not winemetal.so**

The lifetime bug is a property of how the swapchain owns the view, so the refcount belongs with the swapchain's create/destroy. Keeping it PE-side also means it ships without an ABI-coupled winemetal.so rebuild. If you'd prefer the refcount to live in winemetal as a single source of truth for any future caller, happy to move it.

**Testing**

- My Singing Monsters now displays correctly (an easy repro: free, 32-bit).
- Non-regression on single-swapchain apps, which must be behavior-identical: Among Us (Unity, 32-bit), Pool Blitz (UE4, 64-bit), and a UE5 title all render as before. They hit create -> refcount 1, destroy -> release, the same as stock.
- Applies cleanly to master.

**Known minor edge**

`g_metal_views.emplace` could throw std::bad_alloc and leak the freshly created view on OOM. It's an allocation-failure-only path, no worse than the surrounding code, so I left it unguarded to keep the diff minimal. Happy to wrap it if you want it hardened.
