### PR TITLE
fix(d3d11): initialize async compile ready flags

### DIFF
--- a/src/d3d11/d3d11_pipeline.cpp
+++ b/src/d3d11/d3d11_pipeline.cpp
@@ -16,7 +16,7 @@ public:
       : num_rtvs(pDesc->NumColorAttachments),
         depth_stencil_format(pDesc->DepthStencilFormat),
         topology_class(pDesc->TopologyClass), device_(pDevice),
-        pBlendState(pDesc->BlendState),
+        ready_(false), pBlendState(pDesc->BlendState),
         RasterizationEnabled(pDesc->RasterizationEnabled),
         SampleCount(pDesc->SampleCount) {
     uint32_t unorm_output_reg_mask = 0;
@@ -141,7 +141,7 @@ class MTLCompiledComputePipelineImpl
     : public MTLCompiledComputePipeline {
 public:
   MTLCompiledComputePipelineImpl(MTLD3D11Device *pDevice, ManagedShader shader)
-      : device_(pDevice) {
+      : device_(pDevice), ready_(false) {
     ComputeShader = shader->get_shader(ShaderVariantDefault{});
     uint32_t total_tgsize = shader->reflection().ThreadgroupSize[0] *
                             shader->reflection().ThreadgroupSize[1] *

--- a/src/d3d11/d3d11_pipeline_gs.cpp
+++ b/src/d3d11/d3d11_pipeline_gs.cpp
@@ -31,7 +31,7 @@ public:
                               const MTL_GRAPHICS_PIPELINE_DESC *pDesc)
       : num_rtvs(pDesc->NumColorAttachments),
         depth_stencil_format(pDesc->DepthStencilFormat), device_(pDevice),
-        pBlendState(pDesc->BlendState),
+        ready_(false), pBlendState(pDesc->BlendState),
         RasterizationEnabled(pDesc->RasterizationEnabled),
         SampleCount(pDesc->SampleCount) {
     if (pDesc->RasterizationEnabled && !pDesc->PixelShader)

--- a/src/d3d11/d3d11_pipeline_ts.cpp
+++ b/src/d3d11/d3d11_pipeline_ts.cpp
@@ -34,7 +34,7 @@ public:
                                   const MTL_GRAPHICS_PIPELINE_DESC *pDesc)
       : num_rtvs(pDesc->NumColorAttachments),
         depth_stencil_format(pDesc->DepthStencilFormat), device_(pDevice),
-        pBlendState(pDesc->BlendState),
+        ready_(false), pBlendState(pDesc->BlendState),
         RasterizationEnabled(pDesc->RasterizationEnabled),
         SampleCount(pDesc->SampleCount) {
     if (pDesc->RasterizationEnabled && !pDesc->PixelShader)

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -28,7 +28,7 @@ public:
   GeneralShaderCompileTask(MTLD3D11Device *pDevice, ManagedShader shader,
                            Proc &&proc, std::string func_name, const Sha1Digest& variant_digest)
       : CompiledShader(), proc(std::forward<Proc>(proc)), func_name(func_name), device_(pDevice),
-        shader_(shader), variant_digest_(variant_digest) {
+        shader_(shader), variant_digest_(variant_digest), ready_(false) {
     sm50_common.type = SM50_SHADER_COMMON;
     sm50_common.metal_version = (SM50_SHADER_METAL_VERSION)pDevice->GetDXMTDevice().metalVersion();
     sm50_common.flags = getGlobalShaderFlag();


### PR DESCRIPTION
## Summary

Initialize async shader and pipeline compile `ready_` flags to `false` in their constructors.

## Why

These objects expose `GetIsDone()` / `wait(false, ...)` paths before worker completion. Leaving the atomic default state indeterminate can make a newly-created task appear complete before a shader function or pipeline state exists.

Closes #186.

## Validation

- `git diff --check`
