### PR TITLE
build: support Apple Silicon Homebrew LLVM

### DIFF
--- a/src/airconv/darwin/meson.build
+++ b/src/airconv/darwin/meson.build
@@ -14,10 +14,11 @@ llvm_ld_flags_darwin = [
   '-lm', '-lz', '-lcurses', '-lxml2'
 ]
 
-if native_llvm_path.startswith('/usr/local/opt')
+if native_llvm_path.startswith('/usr/local/opt') or native_llvm_path.startswith('/opt/homebrew/opt')
+  homebrew_prefix = native_llvm_path.startswith('/opt/homebrew/opt') ? '/opt/homebrew' : '/usr/local'
   llvm_ld_flags_darwin = [
     llvm_ld_flags_darwin,
-    '/usr/local/opt/zstd/lib/libzstd.a', '/usr/local/opt/llvm@15/lib/libunwind.a'
+    join_paths(homebrew_prefix, 'opt/zstd/lib/libzstd.a'), join_paths(native_llvm_path, 'lib/libunwind.a')
   ]
 endif
 


### PR DESCRIPTION
## Summary

Extend the existing Darwin Homebrew LLVM handling to Apple Silicon:

- recognize `/opt/homebrew/opt` in addition to `/usr/local/opt`
- resolve the static ZSTD archive from the matching Homebrew prefix
- resolve `libunwind.a` from the configured `native_llvm_path`
- keep the existing static LLVM component list unchanged

## Why

With Homebrew LLVM 15 on Apple Silicon, the final native link fails with unresolved ZSTD symbols from `libLLVMSupport.a`. DXMT already supplies Homebrew's static ZSTD and libunwind dependencies for the Intel Homebrew prefix, but the same logic does not run for `/opt/homebrew/opt`.

## Scope

The patch changes only `src/airconv/darwin/meson.build`. It does not change LLVM component selection, Windows cross-build handling, or DXMT's static LLVM linkage.

Closes #192.

## Validation

Tested on macOS/Arm with Homebrew LLVM 15.0.7 at `/opt/homebrew/opt/llvm@15`:

```sh
meson setup build \
  --buildtype release \
  -Denable_tests=false \
  -Dbuild_airconv_for_windows=false \
  -Dnative_llvm_path=/opt/homebrew/opt/llvm@15
meson compile -C build
```

- the complete native build passed: 153/153 steps
- `git diff --check` passed
- `otool -L` for `airconv`, `winemetal.dylib`, and `d3d11.dylib` showed no Homebrew `libLLVM.dylib` dependency
- the existing component list matches `llvm-config --link-static --libs bitwriter passes`
- configuration with a trailing slash in `native_llvm_path` resolves the same ZSTD and libunwind archive paths
