### PR TITLE
fix(winemetal): plug CF/retain leaks (ColorSync + cache init)

### DIFF
--- a/src/winemetal/unix/cache.c
+++ b/src/winemetal/unix/cache.c
@@ -46,20 +46,21 @@ resolve_cache_dir(NSString *path, bool path_is_file) {
     NSString *dbPath = resolve_cache_dir(path, true);
     if (!dbPath) {
       NSLog(@"[CacheReader] Failed to resolve cache path");
+      [self release];
       return nil;
     }
     NSString *tableName = [NSString stringWithFormat:@"cache_%llu", version];
     if (sqlite3_open_v2([dbPath fileSystemRepresentation], &_db, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL) !=
         SQLITE_OK) {
       NSLog(@"[CacheReader] Failed to open DB: %s", sqlite3_errmsg(_db));
-      sqlite3_close(_db);
+      [self release];
       return nil;
     }
 
     NSString *sqlGet = [NSString stringWithFormat:@"SELECT value FROM %@ WHERE key = ?;", tableName];
     if (sqlite3_prepare_v2(_db, sqlGet.UTF8String, -1, &_stmt, NULL) != SQLITE_OK) {
       NSLog(@"[CacheReader] Failed to prepare SELECT: %s", sqlite3_errmsg(_db));
-      sqlite3_close(_db);
+      [self release];
       return nil;
     }
   }
@@ -104,6 +105,7 @@ resolve_cache_dir(NSString *path, bool path_is_file) {
     NSString *dbPath = resolve_cache_dir(path, true);
     if (!dbPath) {
       NSLog(@"[CacheReader] Failed to resolve cache path");
+      [self release];
       return nil;
     }
 
@@ -111,6 +113,7 @@ resolve_cache_dir(NSString *path, bool path_is_file) {
     int fd = open([lockPath fileSystemRepresentation], O_RDWR | O_CREAT, 0666);
     if (fd < 0) {
       NSLog(@"[CacheWriter] Failed to open file for locking %@", lockPath);
+      [self release];
       return nil;
     }
     flock(fd, LOCK_EX);
@@ -122,6 +125,7 @@ resolve_cache_dir(NSString *path, bool path_is_file) {
       NSLog(@"[CacheWriter] Failed to open DB: %s", sqlite3_errmsg(_db));
       flock(fd, LOCK_UN);
       close(fd);
+      [self release];
       return nil;
     }
 
@@ -146,7 +150,7 @@ resolve_cache_dir(NSString *path, bool path_is_file) {
     NSString *sqlSet = [NSString stringWithFormat:@"INSERT OR REPLACE INTO %@ (key, value) VALUES (?, ?);", tableName];
     if (sqlite3_prepare_v2(_db, sqlSet.UTF8String, -1, &_stmt, NULL) != SQLITE_OK) {
       NSLog(@"[CacheWriter] Failed to prepare INSERT: %s", sqlite3_errmsg(_db));
-      sqlite3_close(_db);
+      [self release];
       return nil;
     }
   }

--- a/src/winemetal/unix/winemetal_unix.c
+++ b/src/winemetal/unix/winemetal_unix.c
@@ -2239,16 +2239,21 @@ GetChromaticity_xy(ColorSyncProfileRef profile, CFStringRef tag, float *out_x, f
   CFDataRef tag_data = ColorSyncProfileCopyTag(profile, tag);
   if (!tag_data)
     return false;
-  if (CFDataGetLength(tag_data) != sizeof(icc_XYZ_t))
+  if (CFDataGetLength(tag_data) != sizeof(icc_XYZ_t)) {
+    CFRelease(tag_data);
     return false;
+  }
   icc_XYZ_t *data = (icc_XYZ_t *)CFDataGetBytePtr(tag_data);
-  if (data->sig != 0x205a5958)
+  if (data->sig != 0x205a5958) {
+    CFRelease(tag_data);
     return false;
+  }
   double X = (int32_t)__builtin_bswap32(data->x) / 65536.0;
   double Y = (int32_t)__builtin_bswap32(data->y) / 65536.0;
   double Z = (int32_t)__builtin_bswap32(data->z) / 65536.0;
   *out_x = X / (X + Y + Z);
   *out_y = Y / (X + Y + Z);
+  CFRelease(tag_data);
   return true;
 }
 
@@ -2285,8 +2290,15 @@ _WMTGetDisplayDescription(void *obj) {
   CGDirectDisplayID display_id = params->handle;
   struct WMTDisplayDescription *desc_out = params->arg.ptr;
   ColorSyncProfileRef profile = ColorSyncProfileCreateWithDisplayID(display_id);
-  if (!profile || !GetDisplayColorGamut(profile, desc_out))
-    GetDisplayColorGamut(ColorSyncProfileCreateWithName(kColorSyncGenericRGBProfile), desc_out);
+  if (!profile || !GetDisplayColorGamut(profile, desc_out)) {
+    ColorSyncProfileRef generic = ColorSyncProfileCreateWithName(kColorSyncGenericRGBProfile);
+    if (generic) {
+      GetDisplayColorGamut(generic, desc_out);
+      CFRelease(generic);
+    }
+  }
+  if (profile)
+    CFRelease(profile);
   NSScreen *screen = GetNSScreenForDisplayID(display_id);
   if (screen) {
     desc_out->maximum_edr_color_component_value = [screen maximumExtendedDynamicRangeColorComponentValue];


### PR DESCRIPTION
Two `RetainCount` leaks in the winemetal unix layer, found by clang-tidy (`clang-analyzer-osx.cocoa.RetainCount`):

- **ColorSync** (`winemetal_unix.c`): display-profile CF objects obtained via `Create`/`Copy` were not released on their owning paths.
- **Cache** (`cache.c`): `CacheReader`/`CacheWriter` `-initWithPath:version:` returned `nil` on every failure path without `[self release]`, leaking the alloc'd instance each time. `-dealloc` already owns the sqlite handle cleanup, so the redundant inline `sqlite3_close` on failure is dropped in favour of it.