### PR TITLE
fix(util): fix compilation with Xcode 27 beta

### DIFF
--- a/include/ftl.hpp
+++ b/include/ftl.hpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include <vector>
 #include <algorithm>
+#include <iterator>
 
 template <class Tp, typename Func>
 auto operator | (const std::vector<Tp> &vec, Func &&f)  {

--- a/src/util/sha1/sha1_util.hpp
+++ b/src/util/sha1/sha1_util.hpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <functional>
 #include "./sha1.h"
 
 namespace dxmt {


### PR DESCRIPTION
fixes for two compilation errors:
`In file included from ../src/util/sha1/sha1_util.cpp:12:
../src/util/sha1/sha1_util.hpp:77:20: error: explicit specialization of undeclared template struct 'equal_to'
   77 | template <> struct equal_to<dxmt::Sha1Digest> {`

`In file included from ../src/dxmt/dxmt_format.cpp:1:
../include/ftl.hpp:11:47: error: no member named 'back_inserter' in namespace 'std'
   11 |   std::transform(vec.begin(), vec.end(), std::back_inserter(ret), std::forward<Func>(f));
../include/ftl.hpp:19:47: error: no member named 'back_inserter' in namespace 'std'
   19 |   std::transform(vec.begin(), vec.end(), std::back_inserter(ret), f);`
